### PR TITLE
Better API Token link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plugin for [App Center](https://appcenter.ms). Provides `appcenter_upload` actio
 
 ## Usage
 
-Obtain an [API token](https://docs.microsoft.com/en-us/appcenter/api-docs/). API Token is used for authentication for all App Center API calls.
+[Obtain an API token](https://appcenter.ms/settings/apitokens). API Token is used for authentication for all App Center API calls.
 
 ```ruby
 appcenter_upload(


### PR DESCRIPTION
direct link to generation of api token instead of linking to docs that explain how to test the api via swagger (although it's nice this is possible!)