### PR TITLE
Adds Destination parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The action parameters `api_token` and `owner_name` can also be omitted when thei
 - `APPCENTER_DISTRIBUTE_DSYM` - Path to your symbols file. For iOS provide path to app.dSYM.zip
 - `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` - Flag to upload only the dSYM file to App Center
 - `APPCENTER_DISTRIBUTE_GROUP` - Comma separated list of Distribution Group names
+- `APPCENTER_DISTRIBUTE_DESTINATION` - Comma separated list of Destination names
 - `APPCENTER_DISTRIBUTE_RELEASE_NOTES` - Release notes
 
 ## Example

--- a/fastlane-plugin-appcenter.gemspec
+++ b/fastlane-plugin-appcenter.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/appcenter/version'
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -257,7 +257,7 @@ module Fastlane
         end
       end
 
-       # add release to destination
+      # add release to destination
       def self.add_to_destination(api_token, release_url, destination_name, release_notes = '')
         connection = self.connection
 
@@ -295,7 +295,7 @@ module Fastlane
           false
         end
       end
-      
+
       # run whole upload process for dSYM files
       def self.run_dsym_upload(params)
         values = params.values

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -291,7 +291,7 @@ module Fastlane
           UI.error("Not found, invalid destination name")
           false
         else
-          UI.error("Error adding to group #{response.status}: #{response.body}")
+          UI.error("Error adding to destination #{response.status}: #{response.body}")
           false
         end
       end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -257,6 +257,45 @@ module Fastlane
         end
       end
 
+       # add release to destination
+      def self.add_to_destination(api_token, release_url, destination_name, release_notes = '')
+        connection = self.connection
+
+        response = connection.patch do |req|
+          req.url("/#{release_url}")
+          req.headers['X-API-Token'] = api_token
+          req.headers['internal-request-source'] = "fastlane"
+          req.body = {
+            "destination_name" => destination_name,
+            "release_notes" => release_notes
+          }
+        end
+
+        case response.status
+        when 200...300
+          # get full release info
+          release = self.get_release(api_token, release_url)
+          return false unless release
+          download_url = release['download_url']
+
+          UI.message("DEBUG: #{JSON.pretty_generate(release)}") if ENV['DEBUG']
+
+          Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK] = download_url
+          Actions.lane_context[SharedValues::APPCENTER_BUILD_INFORMATION] = release
+
+          UI.message("Public Download URL: #{download_url}") if download_url
+          UI.success("Release #{release['short_version']} was successfully distributed to destination \"#{destination_name}\"")
+
+          release
+        when 404
+          UI.error("Not found, invalid destination name")
+          false
+        else
+          UI.error("Error adding to group #{response.status}: #{response.body}")
+          false
+        end
+      end
+      
       # run whole upload process for dSYM files
       def self.run_dsym_upload(params)
         values = params.values
@@ -308,6 +347,7 @@ module Fastlane
         owner_name = params[:owner_name]
         app_name = params[:app_name]
         group = params[:group]
+        destination = params[:destination]
         release_notes = params[:release_notes]
         should_clip = params[:should_clip]
         release_notes_link = params[:release_notes_link]
@@ -347,6 +387,10 @@ module Fastlane
             groups = group.split(',')
             groups.each do |group_name|
               self.add_to_group(api_token, release_url, group_name, release_notes)
+            end
+            destinations = destination.split(',')
+            destinations.each do |destination_name|
+              self.add_to_destination(api_token, release_url, destination_name, release_notes)
             end
           end
         end
@@ -535,7 +579,12 @@ module Fastlane
                              default_value: "Collaborators",
                                   optional: true,
                                       type: String),
-
+          FastlaneCore::ConfigItem.new(key: :destination,
+                                  env_name: "APPCENTER_DISTRIBUTE_DESTINATION",
+                               description: "Comma separated list of Destination names",
+                             default_value: "",
+                                  optional: true,
+                                      type: String),
           FastlaneCore::ConfigItem.new(key: :release_notes,
                                   env_name: "APPCENTER_DISTRIBUTE_RELEASE_NOTES",
                                description: "Release notes",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'webmock'
 require 'webmock/rspec'


### PR DESCRIPTION
This add a Destination names parameter which can be used to submit builds automatically to a store.
Example:
```
appcenter_upload(
      app_name: "AppName",
      destination: "iTunes Connect users"
    )
```
This will release every build to TestFlight.