### PR TITLE
Fixed crash

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -325,8 +325,6 @@ module Fastlane
             UI.message("dSYM files zipped")
           end
 
-          values[:dsym_path] = dsym_path
-
           UI.message("Starting dSYM upload...")
           dsym_upload_details = self.create_dsym_upload(api_token, owner_name, app_name)
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -337,6 +337,8 @@ module Fastlane
             UI.message("Uploading dSYM...")
             self.upload_dsym(api_token, owner_name, app_name, dsym_path, symbol_upload_id, upload_url)
           end
+        else
+          UI.user_error!("dSYM file not found")
         end
       end
 


### PR DESCRIPTION
I was getting following error:

`no implicit conversion of Symbol into Integer`

Calling code:

```
params = {
      api_token: 'xxxxxxxxx',
      upload_dsym_only: true,
      owner_name: 'owner',
      app_name: app_name,
      dsym: 'path to dsym',
      release_notes: 'test'
    }
Fastlane::Actions::AppcenterUploadAction.run_dsym_upload(params)
```
