### PR TITLE
Fix crash when printing doc

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -490,9 +490,7 @@ module Fastlane
       end
 
       def self.details
-        [
-          "Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in `:dsym` parameter."
-        ]
+        "Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in `:dsym` parameter."
       end
 
       def self.available_options


### PR DESCRIPTION
Running `fastlane action appcenter_upload` to print the documentation of the plugin/action crashes fastlane, because `self.details` is supposed to be a `String`, not an `Array`.

This commit fixes `self.details` to return a string instead of an array, which will prevent `fastlane action` to crash.