### PR TITLE
Fix obsolete configuration found in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,10 @@ Style/VariableNumber:
   Enabled: false
 
 # This is used a lot across the fastlane code base for config files
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+
+Style/MissingRespondToMissing:
   Enabled: false
 
 #


### PR DESCRIPTION
Currently there is  a TravisCI build error:
```
Error: The `Style/MethodMissing` cop has been split into `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`.
(obsolete configuration found in .rubocop.yml, please update it)
```
This replaces `Style/MethodMissing` with both `Style/MethodMissingSuper` and `Style/MissingRespondToMissing` to fix it.