### PR TITLE
Escape group names

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,24 @@ lane :test_release_notes do
   )
 end
 
+lane :test_group_names do
+  appcenter_upload(
+    api_token: ENV["TEST_APPCENTER_API_TOKEN"],
+    owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
+    app_name: "MyApplication",
+    apk: "./fastlane/app-release.apk",
+    group: "Group%20with%20space"
+  )
+
+  appcenter_upload(
+    api_token: ENV["TEST_APPCENTER_API_TOKEN"],
+    owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
+    app_name: "MyApplication",
+    apk: "./fastlane/app-release.apk",
+    group: "Group with space"
+  )
+end
+
 lane :test do
   # appcenter_upload will read release_notes from FL_CHANGELOG
   Actions.lane_context[SharedValues::FL_CHANGELOG] = 'shared changelog'

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -219,7 +219,7 @@ module Fastlane
         connection = self.connection
 
         response = connection.get do |req|
-          req.url("/v0.1/apps/#{owner_name}/#{app_name}/distribution_groups/#{group_name}")
+          req.url("/v0.1/apps/#{owner_name}/#{app_name}/distribution_groups/#{ERB::Util.url_encode(group_name)}")
           req.headers['X-API-Token'] = api_token
           req.headers['internal-request-source'] = "fastlane"
         end

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -521,7 +521,6 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
-
     it "uses proper api for mandatory release with email notification parameter" do
       stub_check_app(200)
       stub_create_release_upload(200)
@@ -574,6 +573,35 @@ describe Fastlane::Actions::AppcenterUploadAction do
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
           group: 'Testers1,Testers2,Testers3'
+        })
+      end").runner.execute(:test)
+    end
+
+    it "encodes group names" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)      
+      stub_get_group(200, 'Testers%201')
+      stub_get_group(200, 'Testers%202')
+      stub_get_group(200, 'Testers%203')
+      stub_add_to_group(200)
+      stub_add_to_group(200)
+      stub_add_to_group(200)
+      stub_get_release(200)
+      stub_create_dsym_upload(200)
+      stub_upload_dsym(200)
+      stub_update_dsym_upload(200, "committed")
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+          dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+          group: 'Testers 1,Testers 2,Testers 3'
         })
       end").runner.execute(:test)
     end


### PR DESCRIPTION
Fixes error for groups with spaces in name:

```
Found no similar issues. To create a new issue, please visit:
https://github.com/fastlane/fastlane/issues/new
Run `fastlane env` to append the fastlane environment to your issue
bundler: failed to load command: fastlane (/home/circleci/.rubies/ruby-2.4.3/bin/fastlane)
URI::InvalidURIError: [!] bad URI(is not URI?): /v0.1/apps<...>
```