### PR TITLE
Improved docs for notify-testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ appcenter_upload(
   api_token: "<appcenter token>",
   owner_name: "<your appcenter account name>",
   app_name: "<your app name>",
-  apk: "<path to android build binary>"
+  apk: "<path to android build binary>",
+  notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)
 )
 ```
 
@@ -39,7 +40,7 @@ The action parameters `api_token` and `owner_name` can also be omitted when thei
 - `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` - Flag to upload only the dSYM file to App Center
 - `APPCENTER_DISTRIBUTE_GROUP` - Comma separated list of Distribution Group names
 - `APPCENTER_DISTRIBUTE_MANDATORY_UPDATE` - Require users to update to this release
-- `APPCENTER_DISTRIBUTE_NOTIFY_TESTERS` - Send email notification about release
+- `APPCENTER_DISTRIBUTE_NOTIFY_TESTERS` - Send email notification about release (default: `false`)
 - `APPCENTER_DISTRIBUTE_RELEASE_NOTES` - Release notes
 - `APPCENTER_DISTRIBUTE_RELEASE_NOTES_CLIPPING` - Clip release notes if its length is more then 5000, `true` by default
 - `APPCENTER_DISTRIBUTE_RELEASE_NOTES_LINK` - Additional release notes link

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -312,7 +312,8 @@ module Fastlane
             app_name: "testing_app",
             apk: "./app-release.apk",
             group: "Testers",
-            release_notes: "release notes"
+            release_notes: "release notes",
+            notify_testers: false
           )',
           'appcenter_upload(
             api_token: "...",
@@ -321,7 +322,8 @@ module Fastlane
             apk: "./app-release.ipa",
             group: "Testers,Alpha",
             dsym: "./app.dSYM.zip",
-            release_notes: "release notes"
+            release_notes: "release notes",
+            notify_testers: false
           )'
         ]
       end


### PR DESCRIPTION
It was unclear to some people that this param became available and the default changed to `false`