### PR TITLE
Fix error from RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,7 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/AlignHash:


### PR DESCRIPTION
Saw error when running RuboCop

```
Running RuboCop...
Error: The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.
(obsolete configuration found in .rubocop.yml, please update it)
RuboCop failed!
```