### PR TITLE
Replace release_notes_clipping with should_clip in example file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,7 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/AlignHash:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ lane :test_release_notes do
     ipa: "./fastlane/app-release.ipa",
     group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
     release_notes: sh("cat ./test_CHANGELOG.md"),
-    release_notes_clipping: false,
+    should_clip: false,
     release_notes_link: "https://raw.githubusercontent.com/Microsoft/fastlane-plugin-appcenter/master/README.md"
   )
 end


### PR DESCRIPTION
Your example `Fastfile` that's linked to from the README shows a `release_notes_clipping` option. When I run it with that option enabled I get the following error:
```
Could not find option 'release_notes_clipping' in the list of available options: api_token, 
owner_name, app_name, apk, ipa, dsym, upload_dsym_only, group, mandatory_update,
notify_testers, release_notes, should_clip, release_notes_link
```

I assume that the `should_clip` option is the correct one.

Updated the `Fastfile` to use `should_clip` instead