### PR TITLE
Refactor to support destination type, in preparation of supporting distributing to store

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ lane :test_group_names do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    destinations: "Group%20with%20space"
+    destinations: "Group%20with%20space",
     destination_type: "group"
   )
 
@@ -45,7 +45,7 @@ lane :test_group_names do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    destinations: "Group with space"
+    destinations: "Group with space",
     destination_type: "group"
   )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,8 @@ lane :test_release_notes do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication-01",
     ipa: "./fastlane/app-release.ipa",
-    group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destinations: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destination_type: "group",
     release_notes: sh("cat ./test_CHANGELOG.md"),
     release_notes_clipping: false,
     release_notes_link: "https://raw.githubusercontent.com/Microsoft/fastlane-plugin-appcenter/master/README.md"
@@ -35,7 +36,8 @@ lane :test_group_names do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    group: "Group%20with%20space"
+    destinations: "Group%20with%20space"
+    destination_type: "group"
   )
 
   appcenter_upload(
@@ -43,7 +45,8 @@ lane :test_group_names do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    group: "Group with space"
+    destinations: "Group with space"
+    destination_type: "group"
   )
 end
 
@@ -67,7 +70,7 @@ lane :test do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication-01",
     ipa: "./fastlane/app-release.ipa",
-    group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destinations: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
     destination_type: "group",
     release_notes: ENV["TEST_APPCENTER_DISTRIBUTE_RELEASE_NOTES"]
   )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,6 +68,7 @@ lane :test do
     app_name: "MyApplication-01",
     ipa: "./fastlane/app-release.ipa",
     group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destination_type: "group",
     release_notes: ENV["TEST_APPCENTER_DISTRIBUTE_RELEASE_NOTES"]
   )
 
@@ -89,7 +90,8 @@ lane :test do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUPS"]
+    destinations: ENV["TEST_APPCENTER_DISTRIBUTE_GROUPS"],
+    destination_type: "group"
   )
 
   UI.message("\n\n\n=====================================\n uploading mandatory release \n=====================================")
@@ -99,7 +101,8 @@ lane :test do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destinations: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destination_type: "group",
     mandatory_update: true
   )
 
@@ -110,7 +113,8 @@ lane :test do
     owner_name: ENV["TEST_APPCENTER_OWNER_NAME"],
     app_name: "MyApplication",
     apk: "./fastlane/app-release.apk",
-    group: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destinations: ENV["TEST_APPCENTER_DISTRIBUTE_GROUP"],
+    destination_type: "group",
     notify_testers: true
   )
 end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -275,7 +275,7 @@ module Fastlane
                                   optional: true,
                                       type: String,
                               verify_block: proc do |value|
-                                UI.user_error!("No or incorrect destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
+                                UI.user_error!("No or wrong destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
                               end),
 
           FastlaneCore::ConfigItem.new(key: :mandatory_update,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -275,7 +275,7 @@ module Fastlane
                                   optional: true,
                                       type: String,
                               verify_block: proc do |value|
-                                UI.user_error!("No or wrong destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
+                                UI.user_error!("No or incorrect destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
                               end),
 
           FastlaneCore::ConfigItem.new(key: :mandatory_update,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -257,7 +257,7 @@ module Fastlane
                                       type: String,
                                 deprecated: true,
                               verify_block: proc do |value|
-                                UI.user_error!("Option `group` is depreated. Use `destinations` and `destination_type`")
+                                UI.user_error!("Option `group` is deprecated. Use `destinations` and `destination_type`")
                               end),
 
           FastlaneCore::ConfigItem.new(key: :destinations,
@@ -275,7 +275,7 @@ module Fastlane
                                   optional: true,
                                       type: String,
                               verify_block: proc do |value|
-                                UI.user_error!("No or wrong destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
+                                UI.user_error!("No or incorrect destination type given. Use `destination_type: 'group'`") unless value && !value.empty? && value == "group"
                               end),
 
           FastlaneCore::ConfigItem.new(key: :mandatory_update,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -253,7 +253,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :group,
                                   env_name: "APPCENTER_DISTRIBUTE_GROUP",
                                description: "Comma separated list of Distribution Group names",
-                             default_value: "Collaborators",
                                   optional: true,
                                       type: String,
                                 deprecated: true,

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -99,7 +99,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           appcenter_upload({
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             apk: './spec/fixtures/appfiles/apk_file_empty.apk'
           })
         end").runner.execute(:test)
@@ -112,7 +113,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           appcenter_upload({
             api_token: 'xxx',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             apk: './spec/fixtures/appfiles/apk_file_empty.apk'
           })
         end").runner.execute(:test)
@@ -125,7 +127,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           appcenter_upload({
             api_token: 'xxx',
             owner_name: 'owner',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             apk: './spec/fixtures/appfiles/apk_file_empty.apk'
           })
         end").runner.execute(:test)
@@ -140,7 +143,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers'
+            destinations: 'Testers',
+            destination_type: 'group'
           })
         end").runner.execute(:test)
       end.to raise_error("Couldn't find build file at path ''")
@@ -154,7 +158,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             apk: './nothing.apk'
           })
         end").runner.execute(:test)
@@ -169,7 +174,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             ipa: './nothing.ipa'
           })
         end").runner.execute(:test)
@@ -183,7 +189,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             apk: './spec/fixtures/appfiles/Appfile_empty'
           })
         end").runner.execute(:test)
@@ -197,7 +204,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             ipa: './spec/fixtures/appfiles/Appfile_empty'
           })
         end").runner.execute(:test)
@@ -211,12 +219,28 @@ describe Fastlane::Actions::AppcenterUploadAction do
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            group: 'Testers',
+            destinations: 'Testers',
+            destination_type: 'group',
             ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
             apk: './spec/fixtures/appfiles/apk_file_empty.apk'
           })
         end").runner.execute(:test)
       end.to raise_error("You can't use 'ipa' and 'apk' options in one run")
+    end
+
+    it "raises an error if destination type is not group" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            destinations: 'Testers',
+            destination_type: 'random',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("No or wrong destination type given. Use `destination_type: 'group'`")
     end
 
     it "handles upload build error" do
@@ -231,7 +255,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -246,7 +271,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -266,7 +292,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -287,7 +314,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -310,7 +338,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
 
@@ -337,7 +366,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers',
+          destinations: 'Testers',
+          destination_type: 'group',
           release_notes: '#{release_notes}'
         })
       end").runner.execute(:test)
@@ -366,7 +396,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers',
+          destinations: 'Testers',
+          destination_type: 'group',
           release_notes: '#{release_notes}',
           release_notes_link: '#{release_notes_link}'
         })
@@ -391,7 +422,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -413,7 +445,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           api_token: 'xxx',
           owner_name: 'owner',
           app_name: 'app',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
 
@@ -437,7 +470,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           api_token: 'xxx',
           owner_name: 'owner',
           app_name: 'app',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
 
@@ -464,7 +498,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -489,7 +524,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers',
+          destinations: 'Testers',
+          destination_type: 'group',
           mandatory_update: true
         })
       end").runner.execute(:test)
@@ -515,7 +551,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers',
+          destinations: 'Testers',
+          destination_type: 'group',
           notify_testers: true
         })
       end").runner.execute(:test)
@@ -541,7 +578,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers',
+          destinations: 'Testers',
+          destination_type: 'group',
           mandatory_update: true,
           notify_testers: true
         })
@@ -572,7 +610,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers1,Testers2,Testers3'
+          destinations: 'Testers1,Testers2,Testers3',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -601,7 +640,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          group: 'Testers 1,Testers 2,Testers 3'
+          destinations: 'Testers 1,Testers 2,Testers 3',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -623,7 +663,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -638,7 +679,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
     end
@@ -663,7 +705,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM',
-          group: 'Testers'
+          destinations: 'Testers',
+          destination_type: 'group'
         })
       end").runner.execute(:test)
 
@@ -718,7 +761,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
             owner_name: 'owner',
             app_name: 'app',
             apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-            group: 'Testers'
+            destinations: 'Testers',
+            destination_type: 'group'
           })
         end").runner.execute(:test)
       end.to raise_error("Auth Error, provided invalid token")

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -240,7 +240,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
             apk: './spec/fixtures/appfiles/apk_file_empty.apk'
           })
         end").runner.execute(:test)
-      end.to raise_error("No or wrong destination type given. Use `destination_type: 'group'`")
+      end.to raise_error("No or incorrect destination type given. Use `destination_type: 'group'`")
     end
 
     it "handles upload build error" do


### PR DESCRIPTION
First step of address #64 

1. Support `destinations` and `destination_type` as the inputs. Both are optional and default to `Collaborators` distribution group.
2. Only `group` is supported as `destination_type`. Support for others will be added in future PRs.
3. Deprecate `group` input. Throws error when it is used.