### PR TITLE
Fail action on release creation/upload exceptions

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -152,6 +152,8 @@ module Fastlane
                 UI.error("#{destination_type} '#{destination_name}' was not found")
               end
             end
+          else 
+            UI.user_error!("Failed to upload release")
           end
         end
       end

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -48,7 +48,7 @@ module Fastlane
         when 404
           UI.error("Not found, invalid owner or application name")
           false
-        when 500..
+        when 500...600
           UI.crash!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")
@@ -221,7 +221,7 @@ module Fastlane
         when 200...300
           UI.message("DEBUG: #{JSON.pretty_generate(response.body)}\n") if ENV['DEBUG']
           response.body
-        when 500..
+        when 500...600
           UI.crash!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -48,6 +48,8 @@ module Fastlane
         when 404
           UI.error("Not found, invalid owner or application name")
           false
+        when 500..
+          UI.crash!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")
           false

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -221,6 +221,8 @@ module Fastlane
         when 200...300
           UI.message("DEBUG: #{JSON.pretty_generate(response.body)}\n") if ENV['DEBUG']
           response.body
+        when 500..
+          UI.crash!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")
           false

--- a/lib/fastlane/plugin/appcenter/version.rb
+++ b/lib/fastlane/plugin/appcenter/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Appcenter
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -314,22 +314,42 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end.to raise_error("Internal Service Error, please try again later")
     end
 
-    it "handles upload build error" do
-      stub_check_app(200)
-      stub_create_release_upload(200)
-      stub_upload_build(400)
-      stub_update_release_upload(200, 'aborted')
+    it "raises an error on upload build failure" do
+      expect do
+        stub_check_app(200)
+        stub_create_release_upload(200)
+        stub_upload_build(400)
+        stub_update_release_upload(200, 'aborted')
 
-      Fastlane::FastFile.new.parse("lane :test do
-        appcenter_upload({
-          api_token: 'xxx',
-          owner_name: 'owner',
-          app_name: 'app',
-          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
-          destinations: 'Testers',
-          destination_type: 'group'
-        })
-      end").runner.execute(:test)
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("Failed to upload release")
+    end
+
+    it "raises an error on release upload creation auth failure" do
+      expect do
+        stub_check_app(200)
+        stub_create_release_upload(401)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("Auth Error, provided invalid token")
     end
 
     it "handles not found owner or app error" do

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -275,6 +275,27 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end.to raise_error("No or incorrect destination type given. Use 'group' or 'store'")
     end
 
+    it "raises an error on update release upload error" do
+      expect do
+
+        stub_check_app(200)
+        stub_create_release_upload(200)
+        stub_upload_build(200)
+        stub_update_release_upload(500, 'committed')
+
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("Internal Service Error, please try again later")
+    end
+
     it "handles external service response and fails" do
       expect do
         stub_check_app(200)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -275,6 +275,24 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end.to raise_error("No or incorrect destination type given. Use 'group' or 'store'")
     end
 
+    it "handles external service response and fails" do
+      expect do
+        stub_check_app(200)
+        stub_create_release_upload(500)
+        
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("Internal Service Error, please try again later")
+    end
+
     it "handles upload build error" do
       stub_check_app(200)
       stub_create_release_upload(200)


### PR DESCRIPTION
Before, the lane would have just swallowed this error. It would have printed it, but still treated the call as a success.
Now, it will fail execution on a service error, i.e. when this is caused by a service outage, to signal the lane did not succeed.

This should fix wrong treatment as mentioned in #89 

Added this behavior only to the case where initial creation of the release failed and when updating the release upload to completed failed.
For cases where symbol or mapping upload fail we typically don't want to fail the entire upload, as by then the release would have been created and re-uploading might cause another release, while retroactively uploading symbols or mappings can be done independently.