### PR TITLE
Implement support for AAB upload to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ appcenter_upload(
   api_token: "<appcenter token>",
   owner_name: "<your appcenter account name>",
   app_name: "<your app name>",
-  apk: "<path to android build binary>", # Or aab: "<path to aab file>" for app bundles
+  apk: "<path to android build binary>"
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)
 )
 ```
@@ -35,7 +35,7 @@ The action parameters `api_token` and `owner_name` can also be omitted when thei
 - `APPCENTER_OWNER_NAME` - Owner name
 - `APPCENTER_APP_NAME` - App name. If there is no app with such name, you will be prompted to create one
 - `APPCENTER_DISTRIBUTE_APK` - Build release path for android build
-- `APPCENTER_DISTRIBUTE_AAB` - Build release path for android app bundle build
+- `APPCENTER_DISTRIBUTE_AAB` - Build release path for android app bundle build (preview)
 - `APPCENTER_DISTRIBUTE_IPA` - Build release path for ios build
 - `APPCENTER_DISTRIBUTE_DSYM` - Path to your symbols (app.dSYM.zip) file 
 - `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` - Flag to upload only the dSYM file to App Center

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ appcenter_upload(
   api_token: "<appcenter token>",
   owner_name: "<your appcenter account name>",
   app_name: "<your app name>",
-  apk: "<path to android build binary>"
+  apk: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)
 )
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ appcenter_upload(
   api_token: "<appcenter token>",
   owner_name: "<your appcenter account name>",
   app_name: "<your app name>",
-  apk: "<path to android build binary>",
+  apk: "<path to android build binary>", # Or aab: "<path to aab file>" for app bundles
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)
 )
 ```
@@ -35,6 +35,7 @@ The action parameters `api_token` and `owner_name` can also be omitted when thei
 - `APPCENTER_OWNER_NAME` - Owner name
 - `APPCENTER_APP_NAME` - App name. If there is no app with such name, you will be prompted to create one
 - `APPCENTER_DISTRIBUTE_APK` - Build release path for android build
+- `APPCENTER_DISTRIBUTE_AAB` - Build release path for android app bundle build
 - `APPCENTER_DISTRIBUTE_IPA` - Build release path for ios build
 - `APPCENTER_DISTRIBUTE_DSYM` - Path to your symbols (app.dSYM.zip) file 
 - `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` - Flag to upload only the dSYM file to App Center

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -287,7 +287,7 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(key: :aab,
                                   env_name: "APPCENTER_DISTRIBUTE_AAB",
-                               description: "Build release path for android app bundle build",
+                               description: "Build release path for android app bundle build (preview)",
                              default_value: Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
                                   optional: true,
                                       type: String,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -117,7 +117,8 @@ module Fastlane
 
         file = [
           params[:ipa],
-          params[:apk]
+          params[:apk],
+          params[:aab]
         ].detect { |e| !e.to_s.empty? }
 
         UI.user_error!("Couldn't find build file at path '#{file}'") unless file && File.exist?(file)
@@ -274,7 +275,7 @@ module Fastlane
                              default_value: Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
                                   optional: true,
                                       type: String,
-                       conflicting_options: [:ipa],
+                       conflicting_options: [:ipa, :aab],
                             conflict_block: proc do |value|
                               UI.user_error!("You can't use 'apk' and '#{value.key}' options in one run")
                             end,
@@ -283,13 +284,28 @@ module Fastlane
                                 UI.user_error!("Only \".apk\" formats are allowed, you provided \"#{File.extname(value)}\"") unless accepted_formats.include? File.extname(value)
                               end),
 
+          FastlaneCore::ConfigItem.new(key: :aab,
+                                  env_name: "APPCENTER_DISTRIBUTE_AAB",
+                               description: "Build release path for android app bundle build",
+                             default_value: Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+                                  optional: true,
+                                      type: String,
+                       conflicting_options: [:ipa, :apk],
+                            conflict_block: proc do |value|
+                              UI.user_error!("You can't use 'aab' and '#{value.key}' options in one run")
+                            end,
+                              verify_block: proc do |value|
+                                accepted_formats = [".aab"]
+                                UI.user_error!("Only \".aab\" formats are allowed, you provided \"#{File.extname(value)}\"") unless accepted_formats.include? File.extname(value)
+                              end),
+
           FastlaneCore::ConfigItem.new(key: :ipa,
                                   env_name: "APPCENTER_DISTRIBUTE_IPA",
                                description: "Build release path for ios build",
                              default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                   optional: true,
                                       type: String,
-                       conflicting_options: [:apk],
+                       conflicting_options: [:apk, :aab],
                             conflict_block: proc do |value|
                               UI.user_error!("You can't use 'ipa' and '#{value.key}' options in one run")
                             end,
@@ -449,6 +465,19 @@ module Fastlane
             destinations: "Testers,Alpha",
             destination_type: "group",
             dsym: "./app.dSYM.zip",
+            release_notes: "release notes",
+            notify_testers: false
+          )',
+          'appcenter_upload(
+            api_token: "...",
+            owner_name: "appcenter_owner",
+            app_name: "testing_app",
+            aab: "./app.aab",
+            destinations: "Alpha",
+            destination_type: "store",
+            build_number: "3",
+            version: "1.0.0",
+            mapping: "./mapping.txt",
             release_notes: "release notes",
             notify_testers: false
           )'

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -184,7 +184,7 @@ module Fastlane
 
         options = {}
         options[:upload_id] = upload_id
-        # ipa field is used both for .apk and .ipa files
+        # ipa field is used for .apk, .aab and .ipa files
         options[:ipa] = Faraday::UploadIO.new(file, 'application/octet-stream') if file && File.exist?(file)
 
         response = connection.post do |req|

--- a/lib/fastlane/plugin/appcenter/version.rb
+++ b/lib/fastlane/plugin/appcenter/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Appcenter
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
This adds support for Android App Bundle (AAB files) to the stores upload logic.