### PR TITLE
Improve owner_name description

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 ```ruby
 appcenter_upload(
   api_token: "<appcenter token>",
-  owner_name: "<appcenter account name of the owner of the app (user or organization)>",
+  owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
   app_name: "<appcenter app name>",
   apk: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 ```ruby
 appcenter_upload(
   api_token: "<appcenter token>",
-  owner_name: "<your appcenter account name (username or organization)>",
-  app_name: "<your app name>",
+  owner_name: "<appcenter account name of the owner of the app (user or organization)>",
+  app_name: "<appcenter app name>",
   apk: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)
 )

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 ```ruby
 appcenter_upload(
   api_token: "<appcenter token>",
-  owner_name: "<your appcenter account username>",
+  owner_name: "<your appcenter account name (username or organization)>",
   app_name: "<your app name>",
   apk: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 ```ruby
 appcenter_upload(
   api_token: "<appcenter token>",
-  owner_name: "<your appcenter account name>",
+  owner_name: "<your appcenter account username>",
   app_name: "<your app name>",
   apk: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)


### PR DESCRIPTION
When I tried to upload an ipa file to the app center I accidentally used the `name` instead of the `username`. 
This leads to the following error message:
`Error getting app some/App, 403: {"message"=>"Forbidden", "statusCode"=>403, "code"=>"Forbidden"}`

I had to contact the support to solve this problem.
I adjusted the readme file to specify which name the user should use because there are two different user variables for an account.  