### PR TITLE
Support auto-creating apps in App Center organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ appcenter_upload(
 The action parameters `api_token` and `owner_name` can also be omitted when their values are [set as environment variables](https://docs.fastlane.tools/advanced/#environment-variables). Below a list of all available environment variables:
 
 - `APPCENTER_API_TOKEN` - API Token for App Center
+- `APPCENTER_OWNER_TYPE` - Owner type - `user` or `organization` (default value is `user`)
 - `APPCENTER_OWNER_NAME` - Owner name
 - `APPCENTER_APP_NAME` - App name. If there is no app with such name, you will be prompted to create one
 - `APPCENTER_DISTRIBUTE_APK` - Build release path for android build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,17 @@ lane :test_autocreation do
     app_name: "MyApplication-notfound-2",
     apk: "./fastlane/app-release.apk"
   )
+
+  # app should be created for "fastlane-test-org" organisation
+  appcenter_upload(
+    api_token: ENV["TEST_APPCENTER_API_TOKEN"],
+    owner_type: "organization",
+    owner_name: "fastlane-test-org",
+    app_os: 'Android',
+    app_platform: 'Java',
+    app_name: "MyApplication-notfound-3",
+    apk: "./fastlane/app-release.apk"
+  )
 end
 
 lane :test_autocreation_without_prompts do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@ lane :test_autocreation do
     apk: "./fastlane/app-release.apk"
   )
 
-  # app should be created for "fastlane-test-org" organisation
+  # app should be created for "fastlane-test-org" organization
   appcenter_upload(
     api_token: ENV["TEST_APPCENTER_API_TOKEN"],
     owner_type: "organization",

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -243,7 +243,7 @@ module Fastlane
                                       type: String,
                               verify_block: proc do |value|
                                 accepted_formats = ["user", "organization"]
-                                UI.user_error!("Only \"user\" and \"organization\" formats are allowed, you provided \"#{File.extname(value)}\"") unless accepted_formats.include? value
+                                UI.user_error!("Only \"user\" and \"organization\" types are allowed, you provided \"#{File.extname(value)}\"") unless accepted_formats.include? value
                               end),
 
           FastlaneCore::ConfigItem.new(key: :owner_name,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -163,6 +163,7 @@ module Fastlane
       # checks app existance, if ther is no such - creates it
       def self.get_or_create_app(params)
         api_token = params[:api_token]
+        owner_type = params[:owner_type]
         owner_name = params[:owner_name]
         app_name = params[:app_name]
         app_display_name = params[:app_display_name]
@@ -189,7 +190,7 @@ module Fastlane
             (Helper.test? ? "Java" : UI.select("Select Platform", platforms[os])) :
             app_platform
 
-          Helper::AppcenterHelper.create_app(api_token, owner_name, app_name, app_display_name, os, platform)
+          Helper::AppcenterHelper.create_app(api_token, owner_type, owner_name, app_name, app_display_name, os, platform)
         else
           UI.error("Lane aborted")
           false
@@ -232,6 +233,17 @@ module Fastlane
                                       type: String,
                               verify_block: proc do |value|
                                 UI.user_error!("No API token for App Center given, pass using `api_token: 'token'`") unless value && !value.empty?
+                              end),
+
+          FastlaneCore::ConfigItem.new(key: :owner_type,
+                                  env_name: "APPCENTER_OWNER_TYPE",
+                               description: "Owner type",
+                                  optional: true,
+                             default_value: "user",
+                                      type: String,
+                              verify_block: proc do |value|
+                                accepted_formats = ["user", "organization"]
+                                UI.user_error!("Only \"user\" and \"organization\" formats are allowed, you provided \"#{File.extname(value)}\"") unless accepted_formats.include? value
                               end),
 
           FastlaneCore::ConfigItem.new(key: :owner_name,

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -371,10 +371,12 @@ module Fastlane
       end
 
       # returns true if app exists, false in case of 404 and error otherwise
-      def self.create_app(api_token, owner_name, app_name, app_display_name, os, platform)
+      def self.create_app(api_token, owner_type, owner_name, app_name, app_display_name, os, platform)
         connection = self.connection
 
-        response = connection.post("v0.1/apps") do |req|
+        endpoint = owner_type == "user" ? "v0.1/apps" : "v0.1/orgs/#{owner_name}/apps"
+
+        response = connection.post(endpoint) do |req|
           req.headers['X-API-Token'] = api_token
           req.headers['internal-request-source'] = "fastlane"
           req.body = {
@@ -389,7 +391,7 @@ module Fastlane
         when 200...300
           created = response.body
           UI.message("DEBUG: #{JSON.pretty_generate(created)}") if ENV['DEBUG']
-          UI.success("Created #{os}/#{platform} app with name \"#{created['name']}\" and display name \"#{created['display_name']}\"")
+          UI.success("Created #{os}/#{platform} app with name \"#{created['name']}\" and display name \"#{created['display_name']}\" for #{owner_type} \"#{owner_name}\"")
           true
         else
           UI.error("Error creating app #{response.status}: #{response.body}")

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -6,8 +6,8 @@ def stub_check_app(status)
     )
 end
 
-def stub_create_app(status, app_name = "app", app_display_name = "app", app_os = "Android", app_platform = "Java")
-  stub_request(:post, "https://api.appcenter.ms/v0.1/apps")
+def stub_create_app(status, app_name = "app", app_display_name = "app", app_os = "Android", app_platform = "Java", owner_type = "user", owner_name = "owner")
+  stub_request(:post, owner_type == "user" ? "https://api.appcenter.ms/v0.1/apps" : "https://api.appcenter.ms/v0.1/orgs/#{owner_name}/apps")
     .with(
       body: "{\"display_name\":\"#{app_display_name}\",\"name\":\"#{app_name}\",\"os\":\"#{app_os}\",\"platform\":\"#{app_platform}\"}",
     )
@@ -922,6 +922,33 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
+    it "creates app in organization if it was not found with specified os, platform and display_name" do
+      stub_check_app(404)
+      stub_create_app(200, "app", "App Name", "Android", "Java", "organization", "owner")
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)      
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_type: 'organization',
+          owner_name: 'owner',
+          app_name: 'app',
+          app_display_name: 'App Name',
+          app_os: 'Android',
+          app_platform: 'Java',
+          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
     it "handles app creation error" do
       stub_check_app(404)
       stub_create_app(500)
@@ -931,6 +958,25 @@ describe Fastlane::Actions::AppcenterUploadAction do
           api_token: 'xxx',
           owner_name: 'owner',
           app_name: 'app',
+          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
+    it "handles app creation error in org" do
+      stub_check_app(404)
+      stub_create_app(500, "app", "app", "Android", "Java", "organization", "owner")
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_type: 'organization',
+          owner_name: 'owner',
+          app_name: 'app',
+          app_os: 'Android',
+          app_platform: 'Java',
           apk: './spec/fixtures/appfiles/apk_file_empty.apk',
           destinations: 'Testers',
           destination_type: 'group'


### PR DESCRIPTION
* Added optional parameter `owner_type` with values `user` and `organization`, default - `user`

<img width="1253" alt="Screen Shot 2019-08-13 at 10 10 37 PM" src="https://user-images.githubusercontent.com/27571887/62996140-6f75e280-be18-11e9-8e0f-c27ed80fd5c7.png">
