### PR TITLE
Fail fast when trying to distribute .aab to a group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ Gemfile.lock
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+/.idea/
 
 .env

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ The action parameters `api_token` and `owner_name` can also be omitted when thei
 - `APPCENTER_OWNER_NAME` - Owner name
 - `APPCENTER_APP_NAME` - App name. If there is no app with such name, you will be prompted to create one
 - `APPCENTER_DISTRIBUTE_APK` - Build release path for android build
-- `APPCENTER_DISTRIBUTE_AAB` - Build release path for android app bundle build (preview)
+- `APPCENTER_DISTRIBUTE_AAB` - Build release path for android app bundle build
 - `APPCENTER_DISTRIBUTE_IPA` - Build release path for ios build
-- `APPCENTER_DISTRIBUTE_DSYM` - Path to your symbols (app.dSYM.zip) file 
+- `APPCENTER_DISTRIBUTE_DSYM` - Path to your symbols (app.dSYM.zip) file
 - `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` - Flag to upload only the dSYM file to App Center
-- `APPCENTER_DISTRIBUTE_ANDROID_MAPPING` - Path to your Android mapping.txt file 
+- `APPCENTER_DISTRIBUTE_ANDROID_MAPPING` - Path to your Android mapping.txt file
 - `APPCENTER_DISTRIBUTE_UPLOAD_ANDROID_MAPPING_ONLY` - Flag to upload only the mapping file to App Center
 - `APPCENTER_DISTRIBUTE_DESTINATIONS` - Comma separated list of destination names. Both distribution groups and stores are supported. All names are required to be of the same destination type. Default is `Collaborators`.
 - `APPCENTER_DISTRIBUTE_DESTINATION_TYPE` - Destination type of distribution destination. `group` and `store` are supported. Default is `group`

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -44,7 +44,7 @@ module Fastlane
           values[:dsym_path] = dsym_path
 
           UI.message("Starting dSYM upload...")
-          
+
           # TODO: this should eventually be removed once we have warned of deprecation for long enough
           if File.extname(dsym_path) == ".txt"
             file_name = File.basename(dsym_path)
@@ -123,6 +123,7 @@ module Fastlane
         ].detect { |e| !e.to_s.empty? }
 
         UI.user_error!("Couldn't find build file at path '#{file}'") unless file && File.exist?(file)
+        UI.user_error!("Can't distribute .aab to groups. Please use destination type 'store'.") if !params[:aab].nil? && destination_type == "group"
 
         UI.message("Starting release upload...")
         upload_details = Helper::AppcenterHelper.create_release_upload(api_token, owner_name, app_name)
@@ -154,7 +155,7 @@ module Fastlane
                 UI.error("#{destination_type} '#{destination_name}' was not found")
               end
             end
-          else 
+          else
             UI.user_error!("Failed to upload release")
           end
         end
@@ -180,7 +181,7 @@ module Fastlane
         end
 
         should_create_app = !app_display_name.to_s.empty? || !app_os.to_s.empty? || !app_platform.to_s.empty?
-        
+
         if Helper.test? || should_create_app || UI.confirm("App with name #{app_name} not found, create one?")
           app_display_name = app_name if app_display_name.to_s.empty?
           os = app_os.to_s.empty? ?
@@ -299,7 +300,7 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(key: :aab,
                                   env_name: "APPCENTER_DISTRIBUTE_AAB",
-                               description: "Build release path for android app bundle build (preview)",
+                               description: "Build release path for android app bundle build",
                              default_value: Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
                                   optional: true,
                                       type: String,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -123,7 +123,9 @@ module Fastlane
         ].detect { |e| !e.to_s.empty? }
 
         UI.user_error!("Couldn't find build file at path '#{file}'") unless file && File.exist?(file)
-        UI.user_error!("Can't distribute .aab to groups. Please use destination type 'store'.") if !params[:aab].nil? && destination_type == "group"
+        if !params[:aab].to_s.empty? && destination_type == "group"
+          UI.user_error!("Can't distribute .aab to groups. Please use destination type 'store'.")
+        end
 
         UI.message("Starting release upload...")
         upload_details = Helper::AppcenterHelper.create_release_upload(api_token, owner_name, app_name)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -125,6 +125,14 @@ describe Fastlane::Actions::AppcenterUploadAction do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
 
+    after :each do
+      Fastlane::FastFile.new.parse("lane :test do
+        Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = nil
+        Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH] = nil
+        Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = nil
+      end").runner.execute(:test)
+    end
+
     it "raises an error if no api token was given" do
       expect do
         Fastlane::FastFile.new.parse("lane :test do
@@ -201,13 +209,15 @@ describe Fastlane::Actions::AppcenterUploadAction do
     it "raises an error if given aab was not found" do
       expect do
         stub_check_app(200)
+        stub_get_destination(200, 'store', 'Alpha')
+        stub_add_to_destination(200, 'store')
         Fastlane::FastFile.new.parse("lane :test do
           appcenter_upload({
             api_token: 'xxx',
             owner_name: 'owner',
             app_name: 'app',
-            destinations: 'Testers',
-            destination_type: 'group',
+            destinations: 'Alpha',
+            destination_type: 'store',
             aab: './nothing.aab'
           })
         end").runner.execute(:test)
@@ -588,8 +598,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
       stub_upload_build(200)
       stub_update_release_upload(200, 'committed')
       stub_update_release(200)
-      stub_get_destination(200)
-      stub_add_to_destination(200)
+      stub_get_destination(200, 'store', 'Alpha')
+      stub_add_to_destination(200, 'store')
       stub_get_release(200)
 
       Fastlane::FastFile.new.parse("lane :test do
@@ -598,10 +608,34 @@ describe Fastlane::Actions::AppcenterUploadAction do
           owner_name: 'owner',
           app_name: 'app',
           aab: './spec/fixtures/appfiles/aab_file_empty.aab',
-          destinations: 'Testers',
-          destination_type: 'group'
+          destinations: 'Alpha',
+          destination_type: 'store'
         })
       end").runner.execute(:test)
+    end
+
+    it "raises an error when trying to upload an .aab to a group" do
+      expect do
+        stub_check_app(200)
+        stub_create_release_upload(200)
+        stub_upload_build(200)
+        stub_update_release_upload(200, 'committed')
+        stub_update_release(200)
+        stub_get_destination(200)
+        stub_add_to_destination(200)
+        stub_get_release(200)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            aab: './spec/fixtures/appfiles/aab_file_empty.aab',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("Can't distribute .aab to groups. Please use destination type 'store'.")
     end
 
     it "uses GRADLE_APK_OUTPUT_PATH as default for apk" do
@@ -635,8 +669,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
       stub_upload_build(200)
       stub_update_release_upload(200, 'committed')
       stub_update_release(200)
-      stub_get_destination(200)
-      stub_add_to_destination(200)
+      stub_get_destination(200, 'store', 'Alpha')
+      stub_add_to_destination(200, 'store')
       stub_get_release(200)
 
       values = Fastlane::FastFile.new.parse("lane :test do
@@ -646,8 +680,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           api_token: 'xxx',
           owner_name: 'owner',
           app_name: 'app',
-          destinations: 'Testers',
-          destination_type: 'group'
+          destinations: 'Alpha',
+          destination_type: 'store'
         })
       end").runner.execute(:test)
 


### PR DESCRIPTION
Error is now shown before attempting to upload.
While there, remove preview from .aab support.
Ignore .idea folder.