### PR TITLE
Do not log public download URL

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -94,6 +94,7 @@ module Fastlane
         values = params.values
         api_token = params[:api_token]
         owner_name = params[:owner_name]
+        owner_type = params[:owner_type]
         app_name = params[:app_name]
         destinations = params[:destinations]
         destination_type = params[:destination_type]
@@ -166,7 +167,8 @@ module Fastlane
 
           if uploaded
             release_id = uploaded['release_id']
-            UI.message("Release '#{release_id}' committed")
+            release_url = Helper::AppcenterHelper.get_release_url(owner_type, owner_name, app_name, release_id)
+            UI.message("Release '#{release_id}' committed: #{release_url}")
 
             Helper::AppcenterHelper.update_release(api_token, owner_name, app_name, release_id, release_notes)
 
@@ -177,14 +179,17 @@ module Fastlane
                 destination_id = destination['id']
                 distributed_release = Helper::AppcenterHelper.add_to_destination(api_token, owner_name, app_name, release_id, destination_type, destination_id, mandatory_update, notify_testers)
                 if distributed_release
-                  UI.success("Release #{distributed_release['short_version']} was successfully distributed to #{destination_type} \"#{destination_name}\"")
+                  UI.success("Release '#{release_id}' (#{distributed_release['short_version']}) was successfully distributed to #{destination_type} \"#{destination_name}\"")
                 else
-                  UI.error("Release '#{release_id}' was not found")
+                  UI.error("Release '#{release_id}' was not found for destination '#{destination_name}'")
                 end
               else
                 UI.error("#{destination_type} '#{destination_name}' was not found")
               end
             end
+
+            safe_download_url = Helper::AppcenterHelper.get_install_url(owner_type, owner_name, app_name)
+            UI.message("Release '#{release_id}' is available for download at: #{safe_download_url}")
           else
             UI.user_error!("Failed to upload release")
           end

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -16,12 +16,12 @@ module Fastlane
       end
 
       # create request
-      def self.connection(upload_url = false, dsym = false)
+      def self.connection(upload_url = nil, dsym = false)
         require 'faraday'
         require 'faraday_middleware'
 
         options = {
-          url: upload_url ? upload_url : ENV.fetch('APPCENTER_UPLOAD_URL', "https://api.appcenter.ms")
+          url: upload_url || ENV.fetch('APPCENTER_UPLOAD_URL', "https://api.appcenter.ms")
         }
 
         Faraday.new(options) do |builder|
@@ -291,7 +291,7 @@ module Fastlane
           req.headers['X-API-Token'] = api_token
           req.headers['internal-request-source'] = "fastlane"
           req.body = {
-            "release_notes" => release_notes
+            release_notes: release_notes
           }
         end
 
@@ -308,7 +308,7 @@ module Fastlane
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_DOWNLOAD_LINK] = download_url
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION] = release
 
-          UI.message("Release #{release['short_version']} was successfully updated")
+          UI.message("Release '#{release_id}' (#{release['short_version']}) was successfully updated")
 
           release
         when 404
@@ -350,6 +350,8 @@ module Fastlane
 
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_DOWNLOAD_LINK] = download_url
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION] = release
+
+          UI.message("Release '#{release_id}' (#{release['short_version']}) was successfully distributed'")
 
           release
         when 404
@@ -410,6 +412,18 @@ module Fastlane
           UI.error("Error creating app #{response.status}: #{response.body}")
           false
         end
+      end
+
+      # Note: This does not support testing environment (INT)
+      def self.get_release_url(owner_type, owner_name, app_name, release_id)
+        owner_path = owner_type == "user" ? "users/#{owner_name}" : "orgs/#{owner_name}"
+        return "https://appcenter.ms/#{owner_path}/apps/#{app_name}/distribute/releases/#{release_id}"
+      end
+
+      # Note: This does not support testing environment (INT)
+      def self.get_install_url(owner_type, owner_name, app_name)
+        owner_path = owner_type == "user" ? "users/#{owner_name}" : "orgs/#{owner_name}"
+        return "https://install.appcenter.ms/#{owner_path}/apps/#{app_name}"
       end
     end
   end

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -300,6 +300,7 @@ module Fastlane
           # get full release info
           release = self.get_release(api_token, owner_name, app_name, release_id)
           return false unless release
+
           download_url = release['download_url']
 
           UI.message("DEBUG: #{JSON.pretty_generate(release)}") if ENV['DEBUG']
@@ -342,14 +343,13 @@ module Fastlane
           # get full release info
           release = self.get_release(api_token, owner_name, app_name, release_id)
           return false unless release
+
           download_url = release['download_url']
 
           UI.message("DEBUG: received release #{JSON.pretty_generate(release)}") if ENV['DEBUG']
 
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_DOWNLOAD_LINK] = download_url
           Actions.lane_context[Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION] = release
-
-          UI.message("Public Download URL: #{download_url}") if download_url
 
           release
         when 404


### PR DESCRIPTION
It contains secret tokens, and should not be printed out to logs that
may be stored in a CI/CD environment. Rather than obfuscating the
tokens and render an invalid URL, let's just not print the download
URL at all.