### PR TITLE
appcenter_fetch_devices: Add 'destinations' key and some error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ appcenter_fetch_devices(
   api_token: "<appcenter token>",
   owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
   app_name: "<appcenter app name>",
+  destinations: "*", # Default is 'Collaborators', use '*' for all distribution groups
   devices_file: "devices.txt" # Default. If you customize, the extension must be .txt
 )
 ```
@@ -71,6 +72,7 @@ Here is the list of all existing parameters:
 | `api_token` <br/> `APPCENTER_API_TOKEN` | API Token for App Center |
 | `owner_type` <br/> `APPCENTER_OWNER_TYPE` | Owner type, either 'user' or 'organization' (default: `user`) |
 | `owner_name` <br/> `APPCENTER_OWNER_NAME` | Owner name, as found in the App's URL in App Center |
+| `destinations` <br/> `APPCENTER_DISTRIBUTE_DESTINATIONS` | Comma separated list of distribution group names. Default is 'Collaborators', use '*' for all distribution groups |
 | `devices_file` <br/> `FL_REGISTER_DEVICES_FILE` | File to save the devices list to. Same environment variable as _fastlane_'s `register_devices` action |
 
 #### `appcenter_upload`

--- a/fastlane/fetch_devices/Fastfile
+++ b/fastlane/fetch_devices/Fastfile
@@ -2,11 +2,12 @@ desc "Example of automatically provisioning test devices as well as building and
 lane :distribute do
   # Any actions used in this example outside of appcenter_fetch_devices and appcenter_upload ship with fastlane
 
-  # Fetch the list of iOS devices your app is distributed to
+  # Fetch the list of all iOS devices your app is distributed to
   appcenter_fetch_devices(
     api_token: "<appcenter token>",
     owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
     app_name: "<appcenter app name>",
+    destinations: "*",
     devices_file: "test-devices.txt"
   )
 
@@ -20,5 +21,7 @@ lane :distribute do
   gym
 
   # Upload the app
-  appcenter_upload(app_name: appcenter_app_name)
+  appcenter_upload(
+    # All required parameters are propagated from the above actions
+  )
 end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
@@ -126,7 +126,6 @@ module Fastlane
                                   env_name: "APPCENTER_DISTRIBUTE_DESTINATIONS",
                                description: "Comma separated list of distribution group names. Default is 'Collaborators', use '*' for all distribution groups",
                              default_value: "Collaborators",
-                                  optional: true,
                                       type: String)
         ]
       end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
@@ -81,7 +81,9 @@ module Fastlane
       end
 
       def self.details
-        "List is a tab-delimited CSV file containing every device from every distribution group for an app in App Center. Especially useful when combined with register_devices and match to automatically register and provision devices with Apple."
+        "List is a tab-delimited CSV file containing every device from specified distribution groups for an app in App Center. " +
+          "Especially useful when combined with register_devices and match to automatically register and provision devices with Apple. " +
+          "By default, only the Collaborators group will be included, use `destination: '*'` to match all groups."
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.description
-        "Fetches a list of devices from App Center to distribute an iOS app to."
+        "Fetches a list of devices from App Center to distribute an iOS app to"
       end
 
       def self.authors

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_devices_action.rb
@@ -21,7 +21,6 @@ module Fastlane
         Actions.lane_context[SharedValues::APPCENTER_API_TOKEN] = api_token
         Actions.lane_context[SharedValues::APPCENTER_OWNER_NAME] = owner_name
         Actions.lane_context[SharedValues::APPCENTER_APP_NAME] = app_name
-        Actions.lane_context[SharedValues::APPCENTER_DISTRIBUTE_DESTINATIONS] = destinations
 
         group_names = []
         if destinations == '*'
@@ -36,8 +35,10 @@ module Fastlane
             group_names << group['name']
           end
         else
-          group_names += destinations.split(',')
+          group_names += destinations.split(',').map(&:strip)
         end
+
+        Actions.lane_context[SharedValues::APPCENTER_DISTRIBUTE_DESTINATIONS] = group_names.join(',')
 
         devices = []
         group_names.each do |group_name|

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -253,7 +253,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Microsoft", "benkane"]
+        ["Microsoft"]
       end
 
       def self.details
@@ -436,7 +436,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :destinations,
                                   env_name: "APPCENTER_DISTRIBUTE_DESTINATIONS",
                                description: "Comma separated list of destination names. Both distribution groups and stores are supported. All names are required to be of the same destination type",
-                             default_value: "Collaborators",
+                             default_value: Actions.lane_context[SharedValues::APPCENTER_DISTRIBUTE_DESTINATIONS] || "Collaborators",
                                   optional: true,
                                       type: String),
 

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -16,7 +16,7 @@ module Fastlane
       end
 
       # create request
-      def self.connection(upload_url = nil, dsym = false)
+      def self.connection(upload_url = nil, dsym = false, csv = false)
         require 'faraday'
         require 'faraday_middleware'
 
@@ -31,7 +31,7 @@ module Fastlane
           else
             builder.request :json
           end
-          builder.response :json, content_type: /\bjson$/
+          builder.response :json, content_type: /\bjson$/ unless csv
           builder.use FaradayMiddleware::FollowRedirects
           builder.adapter :net_http
         end
@@ -410,6 +410,58 @@ module Fastlane
           true
         else
           UI.error("Error creating app #{response.status}: #{response.body}")
+          false
+        end
+      end
+
+      def self.fetch_distribution_groups(api_token:, owner_name:, app_name:)
+        connection = self.connection
+
+        endpoint = "/v0.1/apps/#{owner_name}/#{app_name}/distribution_groups"
+
+        response = connection.get(endpoint) do |req|
+          req.headers['X-API-Token'] = api_token
+          req.headers['internal-request-source'] = "fastlane"
+        end
+
+        case response.status
+        when 200...300
+          UI.message("DEBUG: #{JSON.pretty_generate(response.body)}\n") if ENV['DEBUG']
+          response.body
+        when 401
+          UI.user_error!("Auth Error, provided invalid token")
+          false
+        when 404
+          UI.error("Not found, invalid owner or application name")
+          false
+        else
+          UI.error("Error #{response.status}: #{response.body}")
+          false
+        end
+      end
+
+      def self.fetch_devices(api_token:, owner_name:, app_name:, distribution_group:)
+        connection = self.connection(nil, false, true)
+
+        endpoint = "/v0.1/apps/#{owner_name}/#{app_name}/distribution_groups/#{ERB::Util.url_encode(distribution_group)}/devices/download_devices_list"
+
+        response = connection.get(endpoint) do |req|
+          req.headers['X-API-Token'] = api_token
+          req.headers['internal-request-source'] = "fastlane"
+        end
+
+        case response.status
+        when 200...300
+          UI.message("DEBUG: #{response.body.inspect}") if ENV['DEBUG']
+          response.body
+        when 401
+          UI.user_error!("Auth Error, provided invalid token")
+          false
+        when 404
+          UI.error("Not found, invalid owner, application or distribution group name")
+          false
+        else
+          UI.error("Error #{response.status}: #{response.body}")
           false
         end
       end


### PR DESCRIPTION
This builds up on the work done in #123 which adds the new action 'appcenter_fetch_devices', but adds a new `destination` key, which I believe will allow for better integration with the `appcenter_upload` action, as well as allowing users with a lot of devices to be have more control over which ones to register.