### PR TITLE
correct-fastlane-dependency: updates minimum fastlane version to 2.96.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To 
 fastlane add_plugin appcenter
 ```
 
+fastlane v2.96.0 or higher is required for all plugin-actions to function properly.
+
 ## About App Center
 With [App Center](https://appcenter.ms) you can continuously build, test, release, and monitor your apps. This plugin provides a set of actions to interact with App Center.
 

--- a/fastlane-plugin-appcenter.gemspec
+++ b/fastlane-plugin-appcenter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'fastlane', '>= 2.29.0'
+  spec.add_development_dependency 'fastlane', '>= 2.96.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
... as `lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]` has been introduced in this version, which is required by `appcenter_upload_action`. Using `appcenter_upload_action` with an older version of fastlane produces the error: ` uninitialized constant Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH`