### PR TITLE
show usage of owner_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 
 ```ruby
 appcenter_fetch_devices(
+  owner_type: "user", # Default is user - set to organisation for appcenter organisations
   api_token: "<appcenter token>",
   owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
   app_name: "<appcenter app name>",
@@ -35,6 +36,7 @@ appcenter_fetch_devices(
 
 ```ruby
 appcenter_upload(
+  owner_type: "user", # Default is user - set to organisation for appcenter organisations
   api_token: "<appcenter token>",
   owner_name: "<appcenter owner name of the app (as seen in app URL)>",
   app_name: "<appcenter app name (as seen in app URL)>",

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To get started, first, [obtain an API token](https://appcenter.ms/settings/apito
 
 ```ruby
 appcenter_fetch_devices(
-  owner_type: "user", # Default is user - set to organisation for appcenter organisations
   api_token: "<appcenter token>",
   owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
+  owner_type: "user", # Default is user - set to organization for appcenter organizations
   app_name: "<appcenter app name>",
   destinations: "*", # Default is 'Collaborators', use '*' for all distribution groups
   devices_file: "devices.txt" # Default. If you customize, the extension must be .txt

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ appcenter_fetch_devices(
 
 ```ruby
 appcenter_upload(
-  owner_type: "user", # Default is user - set to organisation for appcenter organisations
   api_token: "<appcenter token>",
-  owner_name: "<appcenter owner name of the app (as seen in app URL)>",
+  owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
+  owner_type: "user", # Default is user - set to organization for appcenter organizations
   app_name: "<appcenter app name (as seen in app URL)>",
   file: "<path to android build binary>",
   notify_testers: true # Set to false if you don't want to notify testers of your new release (default: `false`)


### PR DESCRIPTION
I've wasted about 1.5 hrs trying different things due to poor error messages on the api when I submit an app to appcenter using this plugin, I'm using an organisation now - previously a user owner_type. so it worked. It wasn't until I searched the issues for this error: `App with name <app_name> not found, create one?` 

Ideally the api should say something useful. or just resolve to an app in an org...

anyway hopefully this updated readme.md will save some people time in the future! maybe force owner_type to be mandatory?