### PR TITLE
Release 1.6.0

### DIFF
--- a/lib/fastlane/plugin/appcenter/version.rb
+++ b/lib/fastlane/plugin/appcenter/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Appcenter
-    VERSION = "1.5.0"
+    VERSION = "1.6.0"
   end
 end


### PR DESCRIPTION
Here's a new release of the App Center fastlane plugin!

This adds support for:
- All known platform and file extensions for upload (see #136)
- Integration with Azure Pipelines with nicely integrated JUnit test results
- `strict` mode which will fail early an upload if the plugin detects an inconsistency

This also deprecates (but does not break support) for:
- `apk:`, `aab:`, `ipa:` fields. They've all been superseded by `file:`.