### PR TITLE
Special case .app.zip extension utility

### DIFF
--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -6,13 +6,9 @@ module Fastlane
       # accounting for file types that can and should be zip-compressed
       # before they are uploaded
       def self.file_extname_full(path)
-        is_zip = File.extname(path) == ".zip"
+        return ".app.zip" if path.end_with? ".app.zip"
 
-        # if file is not .zip'ed, these do not change basename and extname
-        unzip_basename = File.basename(path, ".zip")
-        unzip_extname = File.extname(unzip_basename)
-
-        is_zip ? unzip_extname + ".zip" : unzip_extname
+        File.extname path
       end
 
       # create request

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -6,7 +6,9 @@ module Fastlane
       # accounting for file types that can and should be zip-compressed
       # before they are uploaded
       def self.file_extname_full(path)
-        return ".app.zip" if path.end_with? ".app.zip"
+        %w(.app.zip .dSYM.zip).each do |suffix|
+          return suffix if path.to_s.downcase.end_with? suffix.downcase
+        end
 
         File.extname path
       end


### PR DESCRIPTION
See comment on #136. Only `.app.zip` is specially handled in App Center, no need to have generic code for `.ext.zip`.