### PR TITLE
Adding support for * as destinations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,10 +69,10 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -88,7 +88,7 @@ Style/SymbolArray:
   Enabled: false
 
 # We still support Ruby 2.0.0
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # This cop would not work fine with rspec
@@ -97,7 +97,7 @@ Style/MixinGrouping:
     - '**/spec/**/*'
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,10 +69,10 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/FirstHashElementIndentation:
+Layout/IndentFirstHashElement:
   Enabled: false
 
-Layout/HashAlignment:
+Layout/AlignHash:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -88,7 +88,7 @@ Style/SymbolArray:
   Enabled: false
 
 # We still support Ruby 2.0.0
-Layout/HeredocIndentation:
+Layout/IndentHeredoc:
   Enabled: false
 
 # This cop would not work fine with rspec
@@ -97,7 +97,7 @@ Style/MixinGrouping:
     - '**/spec/**/*'
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/SuppressedException:
+Lint/HandleExceptions:
   Enabled: false
 
 # Cop supports --auto-correct.

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -203,7 +203,7 @@ module Fastlane
 
               UI.abort_with_message!("Failed to list distribution groups for #{owner_name}/#{app_name}") unless distribution_groups
               
-              destination_array = distribution_groups.map {|h| h['name'].downcase }
+              destination_array = distribution_groups.map {|h| h['name'] }
             else
               destinations_array = destinations.split(',').map(&:strip)
             end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -213,7 +213,7 @@ module Fastlane
                 UI.important("Could not find the excluded distribution group: #{group}") unless distribution_group_names.include? group.downcase 
               end
             else
-              destinations_array = destinations.split(',')
+              destinations_array = destinations.split(',').map(&:strip)
             end
             
             destinations_array.each do |destination_name|

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -108,6 +108,7 @@ module Fastlane
         owner_type = params[:owner_type]
         app_name = params[:app_name]
         destinations = params[:destinations]
+        destination_excludes = params[:destination_excludes]
         destination_type = params[:destination_type]
         mandatory_update = params[:mandatory_update]
         notify_testers = params[:notify_testers]

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -108,7 +108,6 @@ module Fastlane
         owner_type = params[:owner_type]
         app_name = params[:app_name]
         destinations = params[:destinations]
-        destination_excludes = params[:destination_excludes]
         destination_type = params[:destination_type]
         mandatory_update = params[:mandatory_update]
         notify_testers = params[:notify_testers]
@@ -202,16 +201,9 @@ module Fastlane
                 app_name: app_name
               )
 
-              destination_excludes_array = destination_excludes.split(',').map(&:strip).map(&:downcase)
               UI.abort_with_message!("Failed to list distribution groups for #{owner_name}/#{app_name}") unless distribution_groups
-              distribution_groups.each do |group|
-                destinations_array << group['name'] unless destination_excludes_array.include? group['name'].downcase 
-              end
-
-              distribution_group_names = distribution_groups.map {|h| h['name'].downcase }
-              destination_excludes_array.each do |group|
-                UI.important("Could not find the excluded distribution group: #{group}") unless distribution_group_names.include? group.downcase 
-              end
+              
+              destination_array = distribution_groups.map {|h| h['name'].downcase }
             else
               destinations_array = destinations.split(',').map(&:strip)
             end
@@ -518,13 +510,6 @@ module Fastlane
                                   optional: true,
                                       type: String),
 
-          FastlaneCore::ConfigItem.new(key: :destination_excludes,
-                                  env_name: "APPCENTER_DISTRIBUTE_DESTINATION_EXCLUDES",
-                               description: "Comma separated list of destination names to be excluded, if destinations is '*'",
-                             default_value: "",
-                                  optional: true,
-                                      type: String),
-
           FastlaneCore::ConfigItem.new(key: :destination_type,
                                   env_name: "APPCENTER_DISTRIBUTE_DESTINATION_TYPE",
                                description: "Destination type of distribution destination. 'group' and 'store' are supported",
@@ -644,7 +629,6 @@ module Fastlane
             app_name: "testing_ios_app",
             file: "./app-release.ipa",
             destinations: "*",
-            destination_excludes: "Collaborators",
             destination_type: "group",
             release_notes: "release notes",
             notify_testers: false

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -505,7 +505,7 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(key: :destinations,
                                   env_name: "APPCENTER_DISTRIBUTE_DESTINATIONS",
-                               description: "Comma separated list of destination names, use '*' for all distribution groups and exclude groups with destination_excludes. Both distribution groups and stores are supported. All names are required to be of the same destination type",
+                               description: "Comma separated list of destination names, use '*' for all distribution groups if destination type is 'group'. Both distribution groups and stores are supported. All names are required to be of the same destination type",
                              default_value: Actions.lane_context[SharedValues::APPCENTER_DISTRIBUTE_DESTINATIONS] || "Collaborators",
                                   optional: true,
                                       type: String),

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -146,6 +146,7 @@ module Fastlane
           self.optional_error("Can't distribute #{file_ext} to groups, please use `destination_type: 'store'`") if Constants::STORE_ONLY_EXTENSIONS.include? file_ext
         else
           self.optional_error("Can't distribute #{file_ext} to stores, please use `destination_type: 'group'`") unless Constants::STORE_SUPPORTED_EXTENSIONS.include? file_ext
+          UI.user_error!("The combination of `destinations: '*'` and `destination_type: 'store'` is invalid, please use `destination_type: 'group'` or explicitly specify the destinations") if destinations == "*"
         end
 
         release_upload_body = nil
@@ -205,6 +206,11 @@ module Fastlane
               UI.abort_with_message!("Failed to list distribution groups for #{owner_name}/#{app_name}") unless distribution_groups
               distribution_groups.each do |group|
                 destinations_array << group['name'] unless destination_excludes_array.include? group['name'].downcase 
+              end
+
+              distribution_group_names = distribution_groups.map {|h| h['name'].downcase }
+              destination_excludes_array.each do |group|
+                UI.important("Could not find the excluded distribution group: #{group}") unless distribution_group_names.include? group.downcase 
               end
             else
               destinations_array = destinations.split(',')
@@ -615,22 +621,23 @@ module Fastlane
           'appcenter_upload(
             api_token: "...",
             owner_name: "appcenter_owner",
-            app_name: "testing_google_play_app",
-            file: "./app.aab",
-            destinations: "Alpha",
-            destination_type: "store",
-            release_notes: "this is a store release"
+            app_name: "testing_ios_app",
+            file: "./app-release.ipa",
+            destinations: "*",
+            destination_excludes: "Collaborators",
+            destination_type: "group",
+            release_notes: "release notes",
+            notify_testers: false
           )',
           'appcenter_upload(
             api_token: "...",
             owner_name: "appcenter_owner",
             app_name: "testing_google_play_app",
             file: "./app.aab",
-            destinations: "*",
-            destination_excludes: "Collaborators",
+            destinations: "Alpha",
             destination_type: "store",
             release_notes: "this is a store release"
-           )'
+          )'
         ]
       end
 

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1498,5 +1498,100 @@ describe Fastlane::Actions::AppcenterUploadAction do
         })
       end").runner.execute(:test)
     end
+
+    it "asterik as destination" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_fetch_distribution_groups(owner_name: 'owner', app_name: 'app')
+      stub_get_destination(200, 'app', 'owner', 'group', 'Collaborators')
+      stub_get_destination(200, 'app', 'owner', 'group', 'test-group-1')
+      stub_get_destination(200, 'app', 'owner', 'group', 'test group 2')
+      stub_add_to_destination(200)
+      stub_add_to_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+      stub_create_dsym_upload(200)
+      stub_upload_dsym(200)
+      stub_update_dsym_upload(200, "committed")
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+          dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+          destinations: '*',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
+    it "asterik as destination and exclude" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_fetch_distribution_groups(owner_name: 'owner', app_name: 'app')
+      stub_get_destination(200, 'app', 'owner', 'group', 'Collaborators')
+      stub_get_destination(200, 'app', 'owner', 'group', 'test-group-1')
+      stub_add_to_destination(200)
+      stub_add_to_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+      stub_create_dsym_upload(200)
+      stub_upload_dsym(200)
+      stub_update_dsym_upload(200, "committed")
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+          dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+          destinations: '*',
+          destination_excludes: 'Test Group 2',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
+    it "asterik as destination for store type" do
+      expect do
+        stub_check_app(200)
+        stub_create_release_upload(200)
+        stub_upload_build(200)
+        stub_update_release_upload(200, 'committed')
+        stub_update_release(200)
+        stub_fetch_distribution_groups(owner_name: 'owner', app_name: 'app')
+        stub_get_destination(200, 'app', 'owner', 'group', 'Collaborators')
+        stub_get_destination(200, 'app', 'owner', 'group', 'test-group-1')
+        stub_get_destination(200, 'app', 'owner', 'group', 'test group 2')
+        stub_add_to_destination(200)
+        stub_add_to_destination(200)
+        stub_add_to_destination(200)
+        stub_get_release(200)
+        stub_create_dsym_upload(200)
+        stub_upload_dsym(200)
+        stub_update_dsym_upload(200, "committed")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'app',
+            ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+            dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+            destinations: '*',
+            destination_type: 'store'
+          })
+        end").runner.execute(:test)
+      end.to raise_error("The combination of `destinations: '*'` and `destination_type: 'store'` is invalid, please use `destination_type: 'group'` or explicitly specify the destinations")
+    end
   end
 end

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1655,37 +1655,6 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
-    it "asterik as destination and exclude" do
-      stub_check_app(200)
-      stub_create_release_upload(200)
-      stub_upload_build(200)
-      stub_update_release_upload(200, 'committed')
-      stub_update_release(200)
-      stub_fetch_distribution_groups(owner_name: 'owner', app_name: 'app')
-      stub_get_destination(200, 'app', 'owner', 'group', 'Collaborators')
-      stub_get_destination(200, 'app', 'owner', 'group', 'test-group-1')
-      stub_add_to_destination(200)
-      stub_add_to_destination(200)
-      stub_add_to_destination(200)
-      stub_get_release(200)
-      stub_create_dsym_upload(200)
-      stub_upload_dsym(200)
-      stub_update_dsym_upload(200, "committed")
-
-      Fastlane::FastFile.new.parse("lane :test do
-        appcenter_upload({
-          api_token: 'xxx',
-          owner_name: 'owner',
-          app_name: 'app',
-          ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
-          dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
-          destinations: '*',
-          destination_excludes: 'Test Group 2',
-          destination_type: 'group'
-        })
-      end").runner.execute(:test)
-    end
-
     it "asterik as destination for store type" do
       expect do
         stub_check_app(200)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1718,7 +1718,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
         end").runner.execute(:test)
       end.to raise_error("The combination of `destinations: '*'` and `destination_type: 'store'` is invalid, please use `destination_type: 'group'` or explicitly specify the destinations")
     end
-    
+
     it "Handles invalid app name error" do
       expect do
         Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Distributing build to all distribution groups by using the '*' as destination. Make exceptions by adding distributions groups to destination_excludes