### PR TITLE
Fix: Priority of deprecated fields and file parameter

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -132,10 +132,10 @@ module Fastlane
         end
 
         file = [
+          params[:file],
           params[:ipa],
           params[:apk],
           params[:aab],
-          params[:file]
         ].detect { |e| !e.to_s.empty? }
 
         UI.user_error!("Couldn't find build file at path '#{file}'") unless file && File.exist?(file)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -913,6 +913,32 @@ describe Fastlane::Actions::AppcenterUploadAction do
       expect(values[:ipa]).to eq('./spec/fixtures/appfiles/ipa_file_empty.ipa')
     end
 
+    it "uses file parameter over default IPA_OUTPUT_PATH and doesn't raise error" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      values = Fastlane::FastFile.new.parse("lane :test do
+        Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] = 'raise_error_if_used.ipa'
+
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          file: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+
+      expect(values[:file]).to eq('./spec/fixtures/appfiles/ipa_file_empty.ipa')
+    end
+
     it "works with valid parameters for ios" do
       stub_check_app(200)
       stub_create_release_upload(200)


### PR DESCRIPTION
Related to: https://github.com/microsoft/fastlane-plugin-appcenter/issues/154

Hi 👋 , took a while to track this one down.

The effect of this bug is not seeing install buttons in Microsoft App Center when released via fastlane but visible when manually creating release via web UI.

We build 2 packages in the one lane for distribution - one via Microsoft App Center (was Hockey) and the other via testflight - 2 streams and 2 different targets.

The first build we send to MS App Center, but only _after_ building the second release, then packaging both with github PRs etc. 

The `ipa` option is deprecated on `appcenter_upload` commands so we use `file`. However there is a mismatch of using `.detect` on the parameters given as that is choosing the _default_ `IPA_OUTPUT_PATH` which has been set by the _second_ Gym build and ignoring the passed `file` parameter.

This PR ensures any passed `file` param is the priority before looking at default values being passed.

