### PR TITLE
Fixing the app creation by handling os correctly

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -232,7 +232,7 @@ module Fastlane
           iOS: %w[Objective-C-Swift React-Native Xamarin],
           macOS: %w[Objective-C-Swift]
         }
-        
+
         if Helper::AppcenterHelper.get_app(api_token, owner_name, app_name)
           return true
         end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -242,7 +242,7 @@ module Fastlane
         if Helper.test? || should_create_app || UI.confirm("App with name #{app_name} not found, create one?")
           app_display_name = app_name if app_display_name.to_s.empty?
           os = app_os.to_s.empty? && (Helper.test? ? "Android" : UI.select("Select OS", platforms.keys)) || app_os.to_s
-          platform = app_platform.to_s.empty? && (Helper.test? ? "Java" : app_platform.to_s) || app_platform.to_s
+          platform = app_platform.to_s.empty? && (Helper.test? && os == "Android" ? "Java" : app_platform.to_s) || app_platform.to_s
           if platform.to_s.empty?
             platform = platforms[os.to_sym].length == 1 ? platforms[os.to_sym][0] : UI.select("Select Platform", platforms[os.to_sym])
           end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -232,7 +232,7 @@ module Fastlane
           iOS: %w[Objective-C-Swift React-Native Xamarin],
           macOS: %w[Objective-C-Swift]
         }
-
+        
         if Helper::AppcenterHelper.get_app(api_token, owner_name, app_name)
           return true
         end
@@ -244,7 +244,7 @@ module Fastlane
           os = app_os.to_s.empty? && (Helper.test? ? "Android" : UI.select("Select OS", platforms.keys)) || app_os.to_s
           platform = app_platform.to_s.empty? && (Helper.test? ? "Java" : app_platform.to_s) || app_platform.to_s
           if platform.to_s.empty?
-            platform = platforms[os].length == 1 ? platforms[os][0] : UI.select("Select Platform", platforms[os])
+            platform = platforms[os.to_sym].length == 1 ? platforms[os.to_sym][0] : UI.select("Select Platform", platforms[os.to_sym])
           end
 
           Helper::AppcenterHelper.create_app(api_token, owner_type, owner_name, app_name, app_display_name, os, platform)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1249,6 +1249,31 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
+    it "creates app if it was not found with specified macOS that supports only one platform" do
+      stub_check_app(404)
+      stub_create_app(200, "app", "App Name", "macOS", "Objective-C-Swift")
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          app_display_name: 'App Name',
+          app_os: 'macOS',
+          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
     it "creates app in organization if it was not found with specified os, platform and display_name" do
       stub_check_app(404)
       stub_create_app(200, "app", "App Name", "Android", "Java", "organization", "owner")

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1267,7 +1267,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           app_display_name: 'App Name',
           app_os: 'macOS',
-          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          file: './spec/fixtures/appfiles/app.zip_file_empty.app.zip',
           destinations: 'Testers',
           destination_type: 'group'
         })


### PR DESCRIPTION
Handling platforms check properly.
Since we verify if the app_platform is provided, if not we prompt the user to select from our `platforms` mapping.
And while doing so, there is an error where we pass platforms[os] instead it should be platforms[os.to_sym]