### PR TITLE
Fixing the platform warning and  bad URI(is not URI?) error

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -238,7 +238,7 @@ module Fastlane
             return true
           end
         rescue URI::InvalidURIError
-          UI.user_error!("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no special charecters and spaces in the app_name.")
+          UI.user_error!("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no special characters or spaces in the app_name.")
           return false
         end
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -238,7 +238,7 @@ module Fastlane
             return true
           end
         rescue URI::InvalidURIError
-          UI.error("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no special charecters and spaces in the app_name.")
+          UI.user_error!("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no special charecters and spaces in the app_name.")
           return false
         end
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -410,7 +410,7 @@ module Fastlane
                                 if platform
                                   accepted_formats = Constants::SUPPORTED_EXTENSIONS[platform.to_sym]
                                   unless accepted_formats
-                                    UI.important("Unknown platform '#{platform}', consider using one of: #{Constants::SUPPORTED_EXTENSIONS.keys}")
+                                    UI.important("Unknown platform '#{platform}', Supported are #{Constants::SUPPORTED_EXTENSIONS.keys}")
                                     accepted_formats = Constants::ALL_SUPPORTED_EXTENSIONS
                                   end
                                   file_ext = Helper::AppcenterHelper.file_extname_full(value)

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -238,7 +238,7 @@ module Fastlane
             return true
           end
         rescue URI::InvalidURIError
-          UI.error("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no spaces in the app_name.")
+          UI.error("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no special charecters and spaces in the app_name.")
           return false
         end
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -407,13 +407,15 @@ module Fastlane
                             end,
                               verify_block: proc do |value|
                                 platform = Actions.lane_context[SharedValues::PLATFORM_NAME]
-                                accepted_formats = Constants::SUPPORTED_EXTENSIONS[platform.to_sym] if platform
-                                unless accepted_formats
-                                  UI.important("Unknown platform '#{platform}', consider using one of: #{Constants::SUPPORTED_EXTENSIONS.keys}")
-                                  accepted_formats = Constants::ALL_SUPPORTED_EXTENSIONS
+                                if platform
+                                  accepted_formats = Constants::SUPPORTED_EXTENSIONS[platform.to_sym]
+                                  unless accepted_formats
+                                    UI.important("Unknown platform '#{platform}', consider using one of: #{Constants::SUPPORTED_EXTENSIONS.keys}")
+                                    accepted_formats = Constants::ALL_SUPPORTED_EXTENSIONS
+                                  end
+                                  file_ext = Helper::AppcenterHelper.file_extname_full(value)
+                                  self.optional_error("Extension not supported: '#{file_ext}'. Supported formats for platform '#{platform}': #{accepted_formats.join ' '}") unless accepted_formats.include? file_ext
                                 end
-                                file_ext = Helper::AppcenterHelper.file_extname_full(value)
-                                self.optional_error("Extension not supported: '#{file_ext}'. Supported formats for platform '#{platform}': #{accepted_formats.join ' '}") unless accepted_formats.include? file_ext
                               end),
 
           FastlaneCore::ConfigItem.new(key: :dsym,

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -233,8 +233,13 @@ module Fastlane
           macOS: %w[Objective-C-Swift]
         }
 
-        if Helper::AppcenterHelper.get_app(api_token, owner_name, app_name)
-          return true
+        begin
+          if Helper::AppcenterHelper.get_app(api_token, owner_name, app_name)
+            return true
+          end
+        rescue URI::InvalidURIError
+          UI.error("Provided app_name: '#{app_name}' is not in a valid format. Please ensure no spaces in the app_name.")
+          return false
         end
 
         should_create_app = !app_display_name.to_s.empty? || !app_os.to_s.empty? || !app_platform.to_s.empty?

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1562,7 +1562,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
             destination_type: 'group'
           })
         end").runner.execute(:test)
-      end.to raise_error(/Please ensure no special charecters and spaces in the app_name./)
+      end.to raise_error(/Please ensure no special characters or spaces in the app_name./)
     end
   end
 end

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1549,5 +1549,20 @@ describe Fastlane::Actions::AppcenterUploadAction do
         })
       end").runner.execute(:test)
     end
+
+    it "Handles invalid app name error" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'appname with space',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group'
+          })
+        end").runner.execute(:test)
+      end.to raise_error(/Please ensure no special charecters and spaces in the app_name./)
+    end
   end
 end


### PR DESCRIPTION
# Issue: 1
As part of the config key :file, we are checking the supported file extensions based on environment variable `SharedValues::PLATFORM_NAME`.
And if this is not present, we are showing incorrect error message.

`[19:34:18]: Unknown platform '', consider using one of: [:android, :ios, :mac, :windows, :custom]`

This is slightly confusing when users are using this for only upload action and doesn't want to set the platform.

# Issue 2
When user gives AppName with spaces/special characters, then url construction for GET is failing with **URI::InvalidURIError: [!] bad URI(is not URI?): v0.1/apps/korea/test app**
If we do URI.encode this error is resolved but fails in app_creation steps with validation errors.

Hence handling this just by rescue-ing on URI::InvalidURIError.