### PR TITLE
Adding support to upload_build_only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Here is the list of all existing parameters:
 | `app_os` <br/> `APPCENTER_APP_OS` | App OS. Used for new app creation, if app 'app_name' was not found |
 | `app_platform` <br/> `APPCENTER_APP_PLATFORM` | App Platform. Used for new app creation, if app 'app_name' was not found |
 | `file` <br/> `APPCENTER_DISTRIBUTE_FILE` | File path to the release build to publish |
+| `upload_build_only` <br/> `APPCENTER_DISTRIBUTE_UPLOAD_BUILD_ONLY` | Flag to upload only the build to App Center. Skips uploading symbols or mapping (default: `false`) |
 | `dsym` <br/> `APPCENTER_DISTRIBUTE_DSYM` | Path to your symbols file. For iOS provide path to app.dSYM.zip |
 | `upload_dsym_only` <br/> `APPCENTER_DISTRIBUTE_UPLOAD_DSYM_ONLY` | Flag to upload only the dSYM file to App Center (default: `false`) |
 | `mapping` <br/> `APPCENTER_DISTRIBUTE_ANDROID_MAPPING` | Path to your Android mapping.txt |

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1498,7 +1498,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
       expect(values[:dsym_path]).to eq('./spec/fixtures/symbols/Themoji.dSYM.zip')
     end
 
-    it "allows to upload build only even if dsym provided when upload_build_only is true"  do
+    it "allows to upload build only even if dsym provided when upload_build_only is true" do
       stub_check_app(200)
       stub_create_release_upload(200)
       stub_upload_build(200)

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1498,7 +1498,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
       expect(values[:dsym_path]).to eq('./spec/fixtures/symbols/Themoji.dSYM.zip')
     end
 
-    it "allows to upload build only" do
+    it "allows to upload build only even if dsym provided when upload_build_only is true"  do
       stub_check_app(200)
       stub_create_release_upload(200)
       stub_upload_build(200)
@@ -1515,6 +1515,30 @@ describe Fastlane::Actions::AppcenterUploadAction do
           app_name: 'app',
           ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
           dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+          destinations: 'Testers',
+          destination_type: 'group',
+          upload_build_only: true
+        })
+      end").runner.execute(:test)
+    end
+
+    it "allows to upload build only even if mapping provided when upload_build_only is true" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          mapping: './spec/fixtures/symbols/mapping.txt',
           destinations: 'Testers',
           destination_type: 'group',
           upload_build_only: true

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1498,6 +1498,30 @@ describe Fastlane::Actions::AppcenterUploadAction do
       expect(values[:dsym_path]).to eq('./spec/fixtures/symbols/Themoji.dSYM.zip')
     end
 
+    it "allows to upload build only" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          ipa: './spec/fixtures/appfiles/ipa_file_empty.ipa',
+          dsym: './spec/fixtures/symbols/Themoji.dSYM.zip',
+          destinations: 'Testers',
+          destination_type: 'group',
+          upload_build_only: true
+        })
+      end").runner.execute(:test)
+    end
+
     it "handles invalid token error" do
       expect do
         stub_check_app(200)
@@ -1563,6 +1587,23 @@ describe Fastlane::Actions::AppcenterUploadAction do
           })
         end").runner.execute(:test)
       end.to raise_error(/Please ensure no special characters or spaces in the app_name./)
+    end
+
+    it "Handles conflicting options of upload_build_only and upload_dysm_only" do
+      expect do
+        Fastlane::FastFile.new.parse("lane :test do
+          appcenter_upload({
+            api_token: 'xxx',
+            owner_name: 'owner',
+            app_name: 'appname',
+            apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+            destinations: 'Testers',
+            destination_type: 'group',
+            upload_build_only: true,
+            upload_dsym_only: true
+          })
+        end").runner.execute(:test)
+      end.to raise_error(/can't use 'upload_build_only' and 'upload_dsym_only' options in one run/)
     end
   end
 end


### PR DESCRIPTION
This is to support few feature requests where customers just want to upload the builds but not symbols.

Hence introduced a new flag called `upload_build_only` 
And when set to true, this will upload build only and skips symbols/mapping