### PR TITLE
Adding windows support for app creation when not exists

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -230,7 +230,8 @@ module Fastlane
         platforms = {
           Android: %w[Java React-Native Xamarin],
           iOS: %w[Objective-C-Swift React-Native Xamarin],
-          macOS: %w[Objective-C-Swift]
+          macOS: %w[Objective-C-Swift],
+          Windows: %w[UWP WPF WinForms Unity]
         }
 
         begin
@@ -247,7 +248,7 @@ module Fastlane
         if Helper.test? || should_create_app || UI.confirm("App with name #{app_name} not found, create one?")
           app_display_name = app_name if app_display_name.to_s.empty?
           os = app_os.to_s.empty? && (Helper.test? ? "Android" : UI.select("Select OS", platforms.keys)) || app_os.to_s
-          platform = app_platform.to_s.empty? && (Helper.test? && os == "Android" ? "Java" : app_platform.to_s) || app_platform.to_s
+          platform = app_platform.to_s.empty? && (Helper.test? ? platforms[os.to_sym][0] : app_platform.to_s) || app_platform.to_s
           if platform.to_s.empty?
             platform = platforms[os.to_sym].length == 1 ? platforms[os.to_sym][0] : UI.select("Select Platform", platforms[os.to_sym])
           end

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1300,6 +1300,32 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
+    it "creates app when app_os is Windows amd selects the app_platform" do
+      stub_check_app(404)
+      stub_create_app(200, "app", "App Name", "Windows", "UWP")
+      stub_create_release_upload(200, { build_version: "1.0" })
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+
+      Fastlane::FastFile.new.parse("lane :test do
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          app_display_name: 'App Name',
+          app_os: 'Windows',
+          file: './spec/fixtures/appfiles/zip_file_empty.zip',
+          version: '1.0',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+    end
+
     it "creates app in organization if it was not found with specified os, platform and display_name" do
       stub_check_app(404)
       stub_create_app(200, "app", "App Name", "Android", "Java", "organization", "owner")

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1300,7 +1300,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
     end
 
-    it "creates app when app_os is Windows amd selects the app_platform" do
+    it "creates app when app_os is Windows and selects the app_platform" do
       stub_check_app(404)
       stub_create_app(200, "app", "App Name", "Windows", "UWP")
       stub_create_release_upload(200, { build_version: "1.0" })


### PR DESCRIPTION
As part of this plugin, we support when app doesn't exists, we have an option to create.
And when we don't provide app_platform, we prompt the users to select from supported platforms.
But this was not supported in Windows case.

Added support to this.