### PR TITLE
use lane_context for android mapping text

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -424,7 +424,7 @@ module Fastlane
                                   self.optional_error("Extension not supported: '#{file_ext}'. Supported formats for platform '#{platform}': #{accepted_formats.join ' '}") unless accepted_formats.include? file_ext
                                 end
                               end),
-          
+
           FastlaneCore::ConfigItem.new(key: :upload_build_only,
                                   env_name: "APPCENTER_DISTRIBUTE_UPLOAD_BUILD_ONLY",
                                description: "Flag to upload only the build to App Center. Skips uploading symbols or mapping",
@@ -460,6 +460,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :mapping,
                                   env_name: "APPCENTER_DISTRIBUTE_ANDROID_MAPPING",
                                description: "Path to your Android mapping.txt",
+                               default_value: Actions.lane_context[SharedValues::GRADLE_MAPPING_TXT_OUTPUT_PATH],
                                   optional: true,
                                       type: String,
                               verify_block: proc do |value|

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -142,6 +142,7 @@ describe Fastlane::Actions::AppcenterUploadAction do
         Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH] = nil
         Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH] = nil
         Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH] = nil
+        Actions.lane_context[SharedValues::GRADLE_MAPPING_TXT_OUTPUT_PATH] = nil
       end").runner.execute(:test)
     end
 
@@ -861,6 +862,35 @@ describe Fastlane::Actions::AppcenterUploadAction do
       end").runner.execute(:test)
 
       expect(values[:apk]).to eq('./spec/fixtures/appfiles/apk_file_empty.apk')
+    end
+
+    it "uses GRADLE_MAPPING_TXT_OUTPUT_PATH as default for mapping" do
+      stub_check_app(200)
+      stub_create_release_upload(200)
+      stub_upload_build(200)
+      stub_update_release_upload(200, 'committed')
+      stub_update_release(200)
+      stub_get_destination(200)
+      stub_add_to_destination(200)
+      stub_get_release(200)
+      stub_create_mapping_upload(200, "1.0.0", "3")
+      stub_upload_mapping(200)
+      stub_update_mapping_upload(200, "committed")
+
+      values = Fastlane::FastFile.new.parse("lane :test do
+        Actions.lane_context[SharedValues::GRADLE_MAPPING_TXT_OUTPUT_PATH] = './spec/fixtures/symbols/mapping.txt'
+
+        appcenter_upload({
+          api_token: 'xxx',
+          owner_name: 'owner',
+          app_name: 'app',
+          apk: './spec/fixtures/appfiles/apk_file_empty.apk',
+          destinations: 'Testers',
+          destination_type: 'group'
+        })
+      end").runner.execute(:test)
+
+      expect(values[:mapping]).to eq('./spec/fixtures/symbols/mapping.txt')
     end
 
     it "uses GRADLE_AAB_OUTPUT_PATH as default for aab" do


### PR DESCRIPTION
uses lane_context[SharedValues:: GRADLE_MAPPING_TXT_OUTPUT_PATH] from gradle plugin to set a default value for mapping.