### PR TITLE
Add debug logs for all API calls (upload action)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -154,7 +154,7 @@ Metrics/ClassLength:
 
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 370
 
 # Configuration parameters: CountKeywordArgs.
@@ -164,7 +164,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 18
 
-BlockNesting:
+Metrics/BlockNesting:
   Max: 4
 
 # Sometimes it's easier to read without guards

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -652,15 +652,21 @@ module Fastlane
         end
       end
 
-      # Note: This does not support testing environment (INT)
       def self.get_release_url(owner_type, owner_name, app_name, release_id)
         owner_path = owner_type == "user" ? "users/#{owner_name}" : "orgs/#{owner_name}"
+        if ENV['APPCENTER_ENV']&.upcase == 'INT'
+          return "https://portal-server-core-integration.dev.avalanch.es/#{owner_path}/apps/#{app_name}/distribute/releases/#{release_id}"
+        end
+
         return "https://appcenter.ms/#{owner_path}/apps/#{app_name}/distribute/releases/#{release_id}"
       end
 
-      # Note: This does not support testing environment (INT)
       def self.get_install_url(owner_type, owner_name, app_name)
         owner_path = owner_type == "user" ? "users/#{owner_name}" : "orgs/#{owner_name}"
+        if ENV['APPCENTER_ENV']&.upcase == 'INT'
+          return "https://install.portal-server-core-integration.dev.avalanch.es/#{owner_path}/apps/#{app_name}"
+        end
+
         return "https://install.appcenter.ms/#{owner_path}/apps/#{app_name}"
       end
     end

--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -59,7 +59,7 @@ module Fastlane
           UI.error("Not found, invalid owner or application name")
           false
         when 500...600
-          UI.crash!("Internal Service Error, please try again later")
+          UI.abort_with_message!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")
           false
@@ -241,7 +241,7 @@ module Fastlane
           UI.user_error!("Auth Error, provided invalid token")
           false
         when 500...600
-          UI.crash!("Internal Service Error, please try again later")
+          UI.abort_with_message!("Internal Service Error, please try again later")
         else
           UI.error("Error #{response.status}: #{response.body}")
           false


### PR DESCRIPTION
For the upload action, this adds full traces of the API calls: URL, body and response contents. Enable this using `export DEBUG=1`.

Also, this fixes invalid calls to inexistent method `UI.crash!`.

Finally, testing by App Center devs is easier by using `APPCENTER_ENV=int` rather than having to set the URL manually. The base URL can also be found in the CLI source code.