### PR TITLE
Add "release_notes" property to appcenter_fetch_version_number output

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ appcenter_fetch_version_number(
 )
 ```
 
-The `appcenter_fetch_version_number` returns a hash that contains the id, the version number, and the build number. The version corresponds to the `short_version` and the build number to the `version` known by App Center for a given release:
+The `appcenter_fetch_version_number` returns a hash that contains the id, the version number, the build number, and the release notes of the most recent release. 
+The version corresponds to the `short_version` and the build number to the `version` known by App Center for a given release:
 ```ruby
-{"id"=>1, "version"=>"1.0.0", "build_number"=>"1.0.0.1234"} # iOS apps contain the full version plus build number due to the way that Apple use CFBundleVersion for this value
-{"id"=>588, "version"=>"1.2.0", "build_number"=>"1615"}
+{"id"=>1, "version"=>"1.0.0", "build_number"=>"1.0.0.1234", "release_notes"=>"Release version 1.0.0"} # iOS apps contain the full version plus build number due to the way that Apple use CFBundleVersion for this value
+{"id"=>588, "version"=>"1.2.0", "build_number"=>"1615", "release_notes"=>"No changelog given"}
 ```
 
 ### Help

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_version_number.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_fetch_version_number.rb
@@ -38,7 +38,8 @@ module Fastlane
         return {
           "id" => latest_release['id'],
           "version" => latest_release['short_version'],
-          "build_number" => latest_release['version']
+          "build_number" => latest_release['version'],
+          "release_notes" => latest_release['release_notes']
         }
       end
 

--- a/spec/appcenter_fetch_version_number_spec.rb
+++ b/spec/appcenter_fetch_version_number_spec.rb
@@ -121,6 +121,7 @@ describe Fastlane::Actions::AppcenterFetchVersionNumberAction do
           expect(version["id"]).to eq(7)
           expect(version["version"]).to eq('1.0.4')
           expect(version["build_number"]).to eq('1.0.4.105')
+          expect(version["release_notes"]).to eq('note 7')
         end
       end
     end

--- a/spec/fixtures/releases/valid_release_response.json
+++ b/spec/fixtures/releases/valid_release_response.json
@@ -51,6 +51,7 @@
     "version": "1.0.4.105",
     "uploaded_at": "2019-09-06T19:33:21.000Z",
     "enabled": true,
+    "release_notes": "note 7",
     "destinations": [
       {
         "id": "aaaaaaaa-1111-1aa1-1aa1-1111aaaa1111",


### PR DESCRIPTION
The release notes of a given AppCenter release may contain pertinent information used for subsequent builds.    For example, in my build, I store the hash of key assets and then use that value on subsequent builds to determine if the package has been changed.

This current  appcenter_fetch_version_number does not output the release_notes.  This PR adds "release_notes" as a property to the output hash of appcenter_fetch_version_number so it can be used in Fastlane builds.