### PR TITLE
Fix appcenter_upload breaks the notarization of the macOS app #214

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -180,7 +180,7 @@ module Fastlane
             File.delete zip_file
           end
           UI.message("Creating zip archive: #{zip_file}")
-          file = Actions::ZipAction.run(path: file, output_path: zip_file)
+          file = Actions::ZipAction.run(path: file, output_path: zip_file, symlinks: true)
         end
 
         UI.message("Starting release upload...")

--- a/spec/appcenter_upload_spec.rb
+++ b/spec/appcenter_upload_spec.rb
@@ -1104,7 +1104,8 @@ describe Fastlane::Actions::AppcenterUploadAction do
           expect(Fastlane::Actions::ZipAction).to receive(:run)
             .with({
               path: './spec/fixtures/appfiles/app_file_empty.app',
-              output_path: './spec/fixtures/appfiles/app_file_empty.app.zip'
+              output_path: './spec/fixtures/appfiles/app_file_empty.app.zip',
+              symlinks: true
             })
 
           Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Hello,

I've found little issue with uploading of the notarized macOS app. I tried to run `appcenter_upload` with notarized _.app_ file, but when I downloaded the uploaded app, the app wasn't notarized.

I've found that the issue is with compressing of the app, which is a part of the `appcenter_upload` action. When the app is compressed without symlinks, it will break notarization of the app. So _.app_ from created _.zip_ file is no longer notarized.

This little adjustment of the `ZipAction` usage resolve that issue.

It fix #214 issue.