### PR TITLE
Chunk large dSYM file uploads

### DIFF
--- a/fastlane-plugin-appcenter.gemspec
+++ b/fastlane-plugin-appcenter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', '>= 2.96.0'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec_junit_formatter'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require 'pry-byebug'
 require 'webmock'
 require 'webmock/rspec'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
+require 'pry-byebug'
 require 'webmock'
 require 'webmock/rspec'
 


### PR DESCRIPTION
Related to #220, fixes #218

We upload dSYMs directly to Azure Blob storage which only supports chunks with a maximum size of 256 MB, see https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
This PR adds logic that uploads files above that size limit in 100 MB chunks. The logic for this is more or less copied from some HockeyApp backend code and adjusted to work with `Faraday`.

**Note: I have not yet actually tested this with a real file!**