### PR TITLE
Add CodePush release-react action

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With [App Center](https://appcenter.ms) you can continuously build, test, releas
 
 `appcenter_fetch_version_number` allows you to obtain the latest version number (short or full) for an app. This is useful for tasks such as getting the latest version of an app so that an increment action can take place on CI, or checking that an upload has been successful.
 
-`appcenter_codepush_release_react` allows you to deploy app updates via CodePuh.
+`appcenter_codepush_release_react` allows you to deploy app updates via CodePush.
 
 ## Usage
 
@@ -149,12 +149,12 @@ Here is the list of all existing parameters:
 | `owner_name` <br/> `APPCENTER_OWNER_NAME` | Owner name, as found in the App's URL in App Center |
 | `app_name` <br/> `APPCENTER_APP_NAME` | App name as found in the App's URL in App Center. If there is no app with such name, you will be prompted to create one |
 | `deployment` <br/> `APPCENTER_CODEPUSH_DEPLOYMENT` | Name of deployment track (default: `Staging`) |
-| `target_version` <br/> `APPCENTER_CODEPUSH_TARGET_VERSION` | Target bunary app version |
+| `target_version` <br/> `APPCENTER_CODEPUSH_TARGET_VERSION` | Target binary app version |
 | `mandatory` <br/> `APPCENTER_CODEPUSH_MANDATORY` | Specifies whether the update should be mandatory (default: `true`) |
 | `description` <br/> `APPCENTER_CODEPUSH_DESCRIPTION` | Description of CodePush release |
 | `dry_run` <br/> `APPCENTER_CODEPUSH_DRY_RUN` | Print command that would be run, don't run it (default: `false`) |
 | `disabled` <br/> `APPCENTER_CODEPUSH_DISABLED` | Specifies whether this release should not be immediately available for download (default: `false`) |
-| `no_duplicate_release_error` <br/> `APPCENTER_CODEPUSH_NO_DUPLICATE_ERROR` | Specifies whether to ignore errors if bundle iss identical to the latest codepush release (default: `false`) |
+| `no_duplicate_release_error` <br/> `APPCENTER_CODEPUSH_NO_DUPLICATE_ERROR` | Specifies whether to ignore errors if bundle is identical to the latest codepush release (default: `false`) |
 | `bundle_name` <br/> `APPCENTER_CODEPUSH_BUNDLE_NAME` | Specifies the name of the bundle file |
 | `output_dir` <br/> `APPCENTER_CODEPUSH_OUTPUT` | Specifies path to where the bundle and sourcemap should be written |
 | `sourcemap_output` <br/> `APPCENTER_CODEPUSH_SOURCEMAP_OUTPUT` | Specifies path to write sourcemaps to |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ With [App Center](https://appcenter.ms) you can continuously build, test, releas
 
 `appcenter_fetch_version_number` allows you to obtain the latest version number (short or full) for an app. This is useful for tasks such as getting the latest version of an app so that an increment action can take place on CI, or checking that an upload has been successful.
 
+`appcenter_codepush_release_react` allows you to deploy app updates via CodePuh.
+
 ## Usage
 
 To get started, first, [obtain an API token](https://appcenter.ms/settings/apitokens) in App Center. The API Token is used to authenticate with the App Center API in each call.
@@ -60,6 +62,15 @@ The `appcenter_fetch_version_number` returns a hash that contains the id, the ve
 ```ruby
 {"id"=>1, "version"=>"1.0.0", "build_number"=>"1.0.0.1234"} # iOS apps contain the full version plus build number due to the way that Apple use CFBundleVersion for this value
 {"id"=>588, "version"=>"1.2.0", "build_number"=>"1615"}
+```
+
+```ruby
+appcenter_codepush_release_react(
+  api_token: "<appcenter token>",
+  owner_name: "<appcenter account name of the owner of the app (username or organization URL name)>",
+  app_name: "<appcenter app name (as seen in app URL)>",
+  deployment: "Staging"
+)
 ```
 
 ### Help
@@ -131,6 +142,24 @@ Here is the list of all existing parameters:
 | `owner_name` <br/> `APPCENTER_OWNER_NAME` | Owner name, as found in the App's URL in App Center |
 | `app_name` <br/> `APPCENTER_APP_NAME` | App name as found in the App's URL in App Center. If there is no app with such name, you will be prompted to create one |
 
+#### `appcenter_codepush_release_react`
+| Key & Env Var | Description |
+|-----------------|--------------------|
+| `api_token` <br/> `APPCENTER_API_TOKEN` | API Token for App Center |
+| `owner_name` <br/> `APPCENTER_OWNER_NAME` | Owner name, as found in the App's URL in App Center |
+| `app_name` <br/> `APPCENTER_APP_NAME` | App name as found in the App's URL in App Center. If there is no app with such name, you will be prompted to create one |
+| `deployment` <br/> `APPCENTER_CODEPUSH_DEPLOYMENT` | Name of deployment track (default: `Staging`) |
+| `target_version` <br/> `APPCENTER_CODEPUSH_TARGET_VERSION` | Target bunary app version |
+| `mandatory` <br/> `APPCENTER_CODEPUSH_MANDATORY` | Specifies whether the update should be mandatory (default: `true`) |
+| `description` <br/> `APPCENTER_CODEPUSH_DESCRIPTION` | Description of CodePush release |
+| `dry_run` <br/> `APPCENTER_CODEPUSH_DRY_RUN` | Print command that would be run, don't run it (default: `false`) |
+| `disabled` <br/> `APPCENTER_CODEPUSH_DISABLED` | Specifies whether this release should not be immediately available for download (default: `false`) |
+| `no_duplicate_release_error` <br/> `APPCENTER_CODEPUSH_NO_DUPLICATE_ERROR` | Specifies whether to ignore errors if bundle iss identical to the latest codepush release (default: `false`) |
+| `bundle_name` <br/> `APPCENTER_CODEPUSH_BUNDLE_NAME` | Specifies the name of the bundle file |
+| `output_dir` <br/> `APPCENTER_CODEPUSH_OUTPUT` | Specifies path to where the bundle and sourcemap should be written |
+| `sourcemap_output` <br/> `APPCENTER_CODEPUSH_SOURCEMAP_OUTPUT` | Specifies path to write sourcemaps to |
+| `development` <br/> `APPCENTER_CODEPUH_DEVELOPMENT` | Specifies whether to generate dev or release build (default: `false`) |
+
 ## Example
 
 Check out this [example `Fastfile`](fastlane/Fastfile) to see how to use the `appcenter_upload` action. Try it by cloning the repo, running `fastlane install_plugins` and `bundle exec fastlane test`.
@@ -183,4 +212,4 @@ Check out [SECURITY.md](SECURITY.md) for any security concern with this project.
 
 ## Contact
 
-We're on Twitter as [@vsappcenter](https://www.twitter.com/vsappcenter). Additionally you can reach out to us on the [App Center](https://appcenter.ms/apps) portal. Open the "?" menu on the top right corner of screen, then use "Contact support" to file a support ticket. Our support team is there to answer your questions and help you solve your problems. 
+We're on Twitter as [@vsappcenter](https://www.twitter.com/vsappcenter). Additionally you can reach out to us on the [App Center](https://appcenter.ms/apps) portal. Open the "?" menu on the top right corner of screen, then use "Contact support" to file a support ticket. Our support team is there to answer your questions and help you solve your problems.

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
@@ -1,0 +1,156 @@
+require 'fastlane_core/ui/ui'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
+
+  module Actions
+    class AppcenterCodepushReleaseReactAction < Action
+      def self.description
+        "CodePush release react action"
+      end
+
+      def self.authors
+        ["Ivan Sokolovskii"]
+      end
+
+      def self.run(params)
+        app = params[:app_name]
+        owner = params[:owner_name]
+        token = params[:api_token]
+        deployment = params[:deployment]
+        dev = paramss[:development]
+        description = params[:description]
+        mandatory = params[:mandatory]
+        version = params[:target_version]
+        disabled = params[:disabled]
+        no_errors = params[:no_duplicate_release_error]
+        bundle = params[:bundle_name]
+        output = params[:output_dir]
+        sourcemap_output = params[:sourcemap_output]
+        dry_run = params[:dry_run]
+
+        command = "appcenter codepush release-react --token #{token} --app #{owner}/#{app} --deployment-name #{deployment} --development #{dev} "
+        if description
+          command += "--description \"#{description}\" "
+        end
+        if mandatory
+          command += "--mandatory "
+        end
+        if version
+          command += "--target-binary-version #{version} "
+        end
+        if disabled
+          command += "--disabled "
+        end
+        if no_errors
+          command += "--disable-duplicate-release-error "
+        end
+        if bundle
+          command += "--bundle-name #{bundle} "
+        end
+        if output
+          command += "--output-dir #{output} "
+        end
+        if sourcemap_output
+          command += "--sourcemap-output #{sourcemap_output} "
+        end
+        if dry_run
+          UI.message("Dry run!".red + " Would have run: " + command + "\n")
+        else
+          sh(command.to_s)
+        end
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                      type: String,
+                                  env_name: "APPCENTER_API_TOKEN",
+                               description: "API Token for App Center Access",
+                              verify_block: proc do |value|
+                                UI.user_error!("No API token for App Center given, pass using `api_token: 'token'`") unless value && !value.empty?
+                              end),
+          FastlaneCore::ConfigItem.new(key: :owner_name,
+                                      type: String,
+                                  env_name: "APPCENTER_OWNER_NAME",
+                               description: "Name of the owner of the application on App Center",
+                              verify_block: proc do |value|
+                                UI.user_error!("No owner name for App Center given, pass using `owner_name: 'owner name'`") unless value && !value.empty?
+                              end),
+          FastlaneCore::ConfigItem.new(key: :app_name,
+                                      type: String,
+                                  env_name: "APPCENTER_APP_NAME",
+                               description: "Name of the application on App Center",
+                              verify_block: proc do |value|
+                                UI.user_error!("No app name for App Center given, pass using `app_name: 'app name'`") unless value && !value.empty?
+                              end),
+          FastlaneCore::ConfigItem.new(key: :deployment,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_DEPLOYMENT",
+                                  optional: true,
+                             default_value: "Staging",
+                               description: "Deployment name for releasing to"),
+          FastlaneCore::ConfigItem.new(key: :target_version,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_TARGET_VERSION",
+                                  optional: true,
+                               description: "Target binary version for example 1.0.1"),
+          FastlaneCore::ConfigItem.new(key: :mandatory,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUSH_MANDATORY",
+                             default_value: true,
+                                  optional: true,
+                               description: "mandatory update or not"),
+          FastlaneCore::ConfigItem.new(key: :description,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_DESCRIPTION",
+                                  optional: true,
+                               description: "Release description for CodePush"),
+          FastlaneCore::ConfigItem.new(key: :dry_run,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUSH_DRY_RUN",
+                             default_value: false,
+                                  optional: true,
+                               description: "Print the command that would be run, and don't run it"),
+          FastlaneCore::ConfigItem.new(key: :disabled,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUSH_DISABLED",
+                             default_value: false,
+                                  optional: true,
+                               description: "Specifies whether this release should be immediately downloadable"),
+          FastlaneCore::ConfigItem.new(key: :no_duplicate_release_error,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUSH_NO_DUPLICATE_ERROR",
+                             default_value: false,
+                                  optional: true,
+                               description: "Specifies whether to return an error if the main bundle is identical to the latest codepush release"),
+          FastlaneCore::ConfigItem.new(key: :bundle_name,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_BUNDLE_NAME",
+                                  optional: true,
+                               description: "Specifies the name of the bundle file"),
+          FastlaneCore::ConfigItem.new(key: :output_dir,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_OUTPUT",
+                                  optional: true,
+                               description: "Specifies path to where the bundle and sourcemap should be written"),
+          FastlaneCore::ConfigItem.new(key: :sourcemap_output,
+                                      type: String,
+                                  env_name: "APPCENTER_CODEPUSH_SOURCEMAP_OUTPUT",
+                                  optional: true,
+                               description: "Specifies path to write sourcemap to"),
+          FastlaneCore::ConfigItem.new(key: :development,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUH_DEVELOPMENT",
+                                  optional: true,
+                             default_value: false,
+                               description: "Specifies whether to generate a dev build")
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :android].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
@@ -18,7 +18,7 @@ module Fastlane
         owner = params[:owner_name]
         token = params[:api_token]
         deployment = params[:deployment]
-        dev = paramss[:development]
+        dev = params[:development]
         description = params[:description]
         mandatory = params[:mandatory]
         version = params[:target_version]
@@ -141,7 +141,7 @@ module Fastlane
                                description: "Specifies path to write sourcemap to"),
           FastlaneCore::ConfigItem.new(key: :development,
                                       type: Boolean,
-                                  env_name: "APPCENTER_CODEPUH_DEVELOPMENT",
+                                  env_name: "APPCENTER_CODEPUSH_DEVELOPMENT",
                                   optional: true,
                              default_value: false,
                                description: "Specifies whether to generate a dev build")


### PR DESCRIPTION
CodePush is part of AppCenter

This Pull request adds support for deploying updates via CodePush for React Native apps
For usage it also requires installation of AppCenter CLI

All necessary options for `appcenter codepush` CLI command are supported
Updated README with description of action's options and small usage example