### PR TITLE
Version 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Here is the list of all existing parameters:
 | `release_notes_link` <br/> `APPCENTER_DISTRIBUTE_RELEASE_NOTES_LINK` | Additional release notes link |
 | `build_number` <br/> `APPCENTER_DISTRIBUTE_BUILD_NUMBER` | The build number, required for macOS .pkg and .dmg builds, as well as Android ProGuard `mapping.txt` when using `upload_mapping_only` |
 | `version` <br/> `APPCENTER_DISTRIBUTE_VERSION` | The build version, required for .pkg, .dmg, .zip and .msi builds, as well as Android ProGuard `mapping.txt` when using `upload_mapping_only` |
-| `timeout` <br/> `APPCENTER_DISTRIBUTE_TIMEOUT` | Request timeout in seconds applied to individual HTTP requests. Some commands use multiple HTTP requests, large file uploads are also split in multiple HTTP requests. |
+| `timeout` <br/> `APPCENTER_DISTRIBUTE_TIMEOUT` | Request timeout in seconds applied to individual HTTP requests. Some commands use multiple HTTP requests, large file uploads are also split in multiple HTTP requests |
 | `dsa_signature` <br/> `APPCENTER_DISTRIBUTE_DSA_SIGNATURE` | DSA signature of the macOS or Windows release for Sparkle update feed |
 | `strict` <br/> `APPCENTER_STRICT_MODE` | Strict mode, set to 'true' to fail early in case a potential error was detected |
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -634,7 +634,7 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        env_name: "APPCENTER_DISTRIBUTE_TIMEOUT",
-                                       description: "Request timeout in seconds",
+                                       description: "Request timeout in seconds applied to individual HTTP requests. Some commands use multiple HTTP requests, large file uploads are also split in multiple HTTP requests",
                                        optional: true,
                                        type: Integer),
 

--- a/lib/fastlane/plugin/appcenter/version.rb
+++ b/lib/fastlane/plugin/appcenter/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Appcenter
-    VERSION = "1.8.1"
+    VERSION = "1.9.0"
   end
 end


### PR DESCRIPTION
* Use the current appcenter upload endpoint to distribute releases.
    * Large release file upload is now split into 4MB chunks (or larger, determined by server response).
    * Each chunk has 2 retries.
* Clarify the timeout request parameter behavior in the documentation.