### PR TITLE
Specify content-type on chunk upload api since the default is not supported

### DIFF
--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -324,6 +324,7 @@ module Fastlane
                 req.options.timeout = timeout
                 req.headers['internal-request-source'] = "fastlane"
                 req.headers['Content-Length'] = chunk.length.to_s
+                req.headers['Content-Type'] = 'application/octet-stream'
                 req.body = chunk
               end
               UI.message("DEBUG: #{response.status} #{JSON.pretty_generate(response.body)}\n") if ENV['DEBUG']


### PR DESCRIPTION
After updating fastlane to 2.161.0 or later, there is a failure when uploading builds using this plugin. The issue appears to be caused by [this change](https://github.com/fastlane/fastlane/commit/7a6b9d684b09c71279daf3471a44bce53a020a53) which altered default behavior for `Content-Type` on requests by any gem loaded by fastlane. As a result, this upload request is now issued with `application/www-x-form-urlencoded` instead of having no `Content-Type` header. Specifying a desired header fixes this issue, though I'm not sure if `application/octet-stream` is correct for this request.

The error seen currently is:
```
Client error: 400: {"error"=>{"code"=>400, "message"=>"The request contains invalid content."}}
```

Fixes #247 and #246 