### PR TITLE
Bump up Ruby version for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # os: osx # enable this if you need macOS support
 language: ruby
 rvm:
-  - 2.2.4
+  - 2.6.5


### PR DESCRIPTION
Since master build failed, update Ruby version of `.travis.yml`.
Version `2.6.5` is taken from `.ruby-version`.