### PR TITLE
Add support for local appcenter cli executable when codepushing

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
@@ -28,8 +28,16 @@ module Fastlane
         output = params[:output_dir]
         sourcemap_output = params[:sourcemap_output]
         dry_run = params[:dry_run]
+        use_local_appcenter_cli = params[:use_local_appcenter_cli]
 
-        command = "appcenter codepush release-react --token #{token} --app #{owner}/#{app} --deployment-name #{deployment} --development #{dev} "
+        base_executable = "appcenter "
+
+        if use_local_appcenter_cli
+          base_executable = "npm exec " + base_executable
+        end
+
+        command = base_executable + "codepush release-react --token #{token} --app #{owner}/#{app} --deployment-name #{deployment} --development #{dev} "
+
         if description
           command += "--description \"#{description}\" "
         end
@@ -144,7 +152,14 @@ module Fastlane
                                   env_name: "APPCENTER_CODEPUSH_DEVELOPMENT",
                                   optional: true,
                              default_value: false,
-                               description: "Specifies whether to generate a dev build")
+                               description: "Specifies whether to generate a dev build"),
+          FastlaneCore::ConfigItem.new(key: :use_local_appcenter_cli,
+                                      type: Boolean,
+                                  env_name: "APPCENTER_CODEPUSH_USE_LOCAL_APPCENTER_CLI",
+                                  optional: true,
+                             default_value: false,
+                             description: "When true, the appcenter cli installed in the project directory is used"),
+
         ]
       end
 

--- a/spec/appcenter_codepush_release_react_spec.rb
+++ b/spec/appcenter_codepush_release_react_spec.rb
@@ -1,0 +1,25 @@
+require_relative 'appcenter_stub'
+require_relative 'upload_stubs'
+
+describe Fastlane::Actions::AppcenterCodepushReleaseReactAction do
+  describe '#run' do
+    before :each do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+      # allow(Fastlane::Actions::AppcenterCodepushReleaseReactAction).to receive(:sh).with(/npm exec/).and_return(nil)
+    end
+
+    it "can use a local appcenter_cli" do
+      allow(Fastlane::Actions::AppcenterCodepushReleaseReactAction).to receive(:sh).with(/npm exec/).and_return(nil)
+      Fastlane::FastFile.new.parse("lane :test_codepush do
+        appcenter_codepush_release_react(
+          api_token: 'an-api-token',
+          owner_name: 'owner',
+          app_name: 'app',
+          deployment: 'Staging',
+          use_local_appcenter_cli: true
+        )
+      end").runner.execute(:test_codepush)
+    end
+  end
+end
+


### PR DESCRIPTION
## Description of Changes

This PR adds a `use_local_appcenter_cli` option to the `appcenter_codepush_release_react` action. When the option is set to `true` the action will use the locally installed appcenter cli.

This means users of the appcenter plugin can install the appcenter cli with the rest of their node modules. This allows for better package hygiene in the CI and development environment. 