### PR TITLE
Add `return true` to `Helper::AppcenterHelper.upload_build`

### DIFF
--- a/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
+++ b/lib/fastlane/plugin/appcenter/helper/appcenter_helper.rb
@@ -421,6 +421,7 @@ module Fastlane
           end
         end
         UI.message("Binary uploaded")
+        return true
       end
 
       # Commits or aborts the upload process for a release


### PR DESCRIPTION
Fix failure of 'appcenter_upload' action when used alongside 'sentry-ruby' Gem

This pull request addresses an issue where the absence of a return value in the `Helper::AppcenterHelper.upload_build` method causes interference between Fastlane's UI and the Sentry logger. To resolve this problem, a `return true` statement is added to ensure a consistent return value from the method.

The `upload_build` method, internally called by the `appcenter_upload`  action currently lacks an explicit return value, relying on the implicit return of the last line, which is  `UI.message("Binary uploaded")`.

However, when the Sentry logger is initialized, it interferes with Fastlane's UI, resulting in an undefined return value for `UI.message`. To prevent any potential issues and ensure a reliable return value, this pull request adds `return true` as the final line of the `upload_build` method.

By explicitly returning `true`, we guarantee a consistent return value from `upload_build`, regardless of the presence or behavior of the Sentry logger. This modification will ensure that the `appcenter upload` action can correctly check the return value of `upload_build` and raise exceptions as intended.

The proposed changes have been thoroughly tested and have successfully resolved the issue in a local environment.