### PR TITLE
Make sure app_distribution_groups is an array before accessing it

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_upload_action.rb
@@ -327,6 +327,11 @@ module Fastlane
           app_name: params[:app_name]
         )
 
+        unless app_distribution_groups.is_a?(Array)
+          UI.error("Failed to fetch distribution groups for app #{params[:app_name]}.")
+          return
+        end
+
         group_names = app_distribution_groups.map { |g| g['name'] }
         destination_names = params[:destinations].split(',').map(&:strip)
 


### PR DESCRIPTION
This PR fixes a misleading ruby error caused by parsing a non-array object received from backend.

[AB#102654](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/102654)
#322