### PR TITLE
fix(local cli): prevent npm from parsing arguments

### DIFF
--- a/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
@@ -37,7 +37,7 @@ module Fastlane
         base_executable = "appcenter "
 
         if use_local_appcenter_cli
-          base_executable = "npm exec " + base_executable
+          base_executable = "npm exec -- " + base_executable
         end
 
         command = base_executable + "codepush release-react --token #{token} --app #{owner}/#{app} --deployment-name #{deployment} --development #{dev} "


### PR DESCRIPTION
Prevent npm from parsing arguments. Without this, devs cannot use local cli.

https://docs.npmjs.com/cli/v7/commands/npm-exec#npx-vs-npm-exec