### PR TITLE
Add codepush support for extra bundler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ Here is the list of all existing parameters:
 | `bundle_name` <br/> `APPCENTER_CODEPUSH_BUNDLE_NAME` | Specifies the name of the bundle file |
 | `output_dir` <br/> `APPCENTER_CODEPUSH_OUTPUT` | Specifies path to where the bundle and sourcemap should be written |
 | `sourcemap_output` <br/> `APPCENTER_CODEPUSH_SOURCEMAP_OUTPUT` | Specifies path to write sourcemaps to |
-| `development` <br/> `APPCENTER_CODEPUH_DEVELOPMENT` | Specifies whether to generate dev or release build (default: `false`) |
+| `development` <br/> `APPCENTER_CODEPUSH_DEVELOPMENT` | Specifies whether to generate dev or release build (default: `false`) |
 | `private_key_path` <br/> `APPCENTER_CODEPUSH_PRIVATE_KEY_PATH` | Specifies path to private key that will be used for signing bundles |
+| `extra_bundler_options` <br/> `APPCENTER_CODEPUSH_EXTRA_BUNDLER_OPTIONS` | A list of extra options that get passed to the react-native bundler |
 
 ## Example
 

--- a/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
+++ b/lib/fastlane/plugin/appcenter/actions/appcenter_codepush_release_react.rb
@@ -33,6 +33,7 @@ module Fastlane
         plist_file = params[:plist_file]
         xcode_project_file = params[:xcode_project_file]
         use_hermes = params[:use_hermes]
+        extra_bundler_options = params[:extra_bundler_options]
 
         base_executable = "appcenter "
 
@@ -78,6 +79,10 @@ module Fastlane
         unless use_hermes.nil?
           command += "--use-hermes #{use_hermes} "
         end
+        if extra_bundler_options
+          command += extra_bundler_options.map { |option| "--extra-bundler-option='#{option}' " }.join
+        end
+
         if dry_run
           UI.message("Dry run!".red + " Would have run: " + command + "\n")
         else
@@ -174,17 +179,17 @@ module Fastlane
                                   env_name: "APPCENTER_CODEPUSH_USE_LOCAL_APPCENTER_CLI",
                                   optional: true,
                              default_value: false,
-                             description: "When true, the appcenter cli installed in the project directory is used"),
+                               description: "When true, the appcenter cli installed in the project directory is used"),
           FastlaneCore::ConfigItem.new(key: :plist_file,
                                       type: String,
                                   env_name: "APPCENTER_CODEPUSH_PLIST_FILE",
                                   optional: true,
-                             description: "Path to the Info.plist"),
+                               description: "Path to the Info.plist"),
           FastlaneCore::ConfigItem.new(key: :xcode_project_file,
                                       type: String,
                                   env_name: "APPCENTER_CODEPUSH_XCODE_PROJECT_FILE",
                                   optional: true,
-                             description: "Path to the .pbxproj file"),
+                               description: "Path to the .pbxproj file"),
           FastlaneCore::ConfigItem.new(key: :private_key_path,
                                       type: String,
                                   env_name: "APPCENTER_CODEPUSH_PRIVATE_KEY_PATH",
@@ -194,7 +199,12 @@ module Fastlane
                                       type: Boolean,
                                   env_name: "APPCENTER_CODEPUSH_USE_HERMES",
                                   optional: true,
-                               description: "Enable hermes and bypass automatic checks")
+                               description: "Enable hermes and bypass automatic checks"),
+          FastlaneCore::ConfigItem.new(key: :extra_bundler_options,
+                                      type: Array,
+                                  env_name: "APPCENTER_CODEPUSH_EXTRA_BUNDLER_OPTIONS",
+                                  optional: true,
+                               description: "Options that get passed to the react-native bundler"),
         ]
       end
 

--- a/spec/appcenter_codepush_release_react_spec.rb
+++ b/spec/appcenter_codepush_release_react_spec.rb
@@ -46,6 +46,21 @@ describe Fastlane::Actions::AppcenterCodepushReleaseReactAction do
         )
       end").runner.execute(:test_codepush)
     end
+
+    it "can add extra bundler options" do
+      allow(Fastlane::Actions::AppcenterCodepushReleaseReactAction).to(
+        receive(:sh).with(/--extra-bundler-option='--reset-cache' --extra-bundler-option='--max-workers=1'/)
+      )
+
+      Fastlane::FastFile.new.parse("lane :test_codepush do
+        appcenter_codepush_release_react(
+          api_token: 'an-api-token',
+          owner_name: 'owner',
+          app_name: 'app',
+          deployment: 'Staging',
+          extra_bundler_options: ['--reset-cache', '--max-workers=1'],
+        )
+      end").runner.execute(:test_codepush)
+    end
   end
 end
-


### PR DESCRIPTION
Add codepush support for the appcenter-cli extra bundler options

Resolves #312 