### PR TITLE
Add csv explicitly dependency as it was removed in 3.4.0

### DIFF
--- a/fastlane-plugin-appcenter.gemspec
+++ b/fastlane-plugin-appcenter.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  
+  spec.add_runtime_dependency 'csv'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', '>= 2.96.0'


### PR DESCRIPTION
Adds csv dependency as it was removed from default gems starting from Ruby 3.4.0.

[AB#104379] (https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/104379)
https://github.com/microsoft/fastlane-plugin-appcenter/issues/338/